### PR TITLE
feat!: slack fallback channel and default gh token

### DIFF
--- a/.github/workflows/accept.yml
+++ b/.github/workflows/accept.yml
@@ -12,9 +12,6 @@ on:
     workflows: ['accept-test']
     types: [completed]
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
-
 jobs:
   test:
     strategy:
@@ -26,6 +23,7 @@ jobs:
       - uses: ./accept
         with:
           dry-run: true
+          gh-token: ${{ secrets.GH_BOT_TOKEN }}
 
   test-filter:
     strategy:
@@ -38,3 +36,4 @@ jobs:
         with:
           filter: non_existing_folder/**
           dry-run: true
+          gh-token: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -10,11 +10,6 @@ on:
       - 'lib/s3*'
       - 'db/**'
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
-
 jobs:
   test:
     strategy:
@@ -36,3 +31,6 @@ jobs:
           branch: develop
           mode: ${{ matrix.mode }}
           version: ${{ matrix.version }}
+          gh-token: ${{ secrets.GH_BOT_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -9,9 +9,6 @@ on:
       - 'lib/s3*'
       - 'deploy-image/**'
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
-
 jobs:
   test-deploy:
     runs-on: ubuntu-latest
@@ -35,5 +32,6 @@ jobs:
           dockerfile: fixtures/Dockerfile
           docker-hub-user: ${{ secrets.DOCKER_HUB_USER }}
           docker-hub-password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          gh-token: ${{ secrets.GH_BOT_TOKEN }}
         env:
           EMULATE_DELETE: 1

--- a/.github/workflows/dummy-data.yml
+++ b/.github/workflows/dummy-data.yml
@@ -8,9 +8,6 @@ on:
       - 'lib/github.ts'
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
   EXIVITY_HOME_PATH: ${{ github.workspace }}/exivity/home
   EXIVITY_PROGRAM_PATH: ${{ github.workspace }}/exivity/program
 
@@ -29,5 +26,8 @@ jobs:
       - uses: ./db
         with:
           branch: develop
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          gh-token: ${{ secrets.GH_BOT_TOKEN }}
       - uses: ./dummy-data
         continue-on-error: true

--- a/.github/workflows/get-artefacts.yml
+++ b/.github/workflows/get-artefacts.yml
@@ -9,11 +9,6 @@ on:
       - 'lib/s3*'
       - 'get-artefacts/**'
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
-
 jobs:
   test:
     strategy:
@@ -26,3 +21,6 @@ jobs:
         with:
           component: actions
           branch: master
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          gh-token: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/put-artefacts.yml
+++ b/.github/workflows/put-artefacts.yml
@@ -8,10 +8,6 @@ on:
       - 'lib/s3*'
       - 'put-artefacts/**'
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
 jobs:
   test:
     strategy:
@@ -25,3 +21,5 @@ jobs:
         with:
           path: fixtures/build
           zip: ${{ matrix.zip }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,9 +7,6 @@ on:
       - 'review/**'
       - 'lib/github.ts'
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
-
 jobs:
   test:
     strategy:
@@ -19,3 +16,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./review
+        with:
+          gh-token: ${{ secrets.GH_BOT_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ repository migrations and runs them.
 | `db-name`               |          | `"exdb-test"`                                                                    | The db name to create.                                                                                                                                                                                |
 | `mode`                  |          | `"host"`                                                                         | Whether to run PostgreSQL as a Docker container or start the server installed on the host. Either `"host"` or `"docker"`.                                                                             |
 | `version`               |          | `"14.0"`                                                                         | The PostgreSQL version to use. Only affects Docker mode (host mode always uses default version). Make sure to use a string type to avoid truncation. Available versions: `"14.0"`, `"13.0"`, `"12.3"` |
-| `aws-access-key-id`     |          | `env.AWS_ACCESS_KEY_ID`                                                          | The AWS access key ID                                                                                                                                                                                 |
-| `aws-secret-access-key` |          | `env.AWS_SECRET_ACCESS_KEY`                                                      | The AWS secret access key                                                                                                                                                                             |
+| `aws-access-key-id`     | ✅       |                                                                                  | The AWS access key ID                                                                                                                                                                                 |
+| `aws-secret-access-key` | ✅       |                                                                                  | The AWS secret access key                                                                                                                                                                             |
 | `gh-token`              |          | `github.token`                                                                   | A GitHub token with access to the exivity/db repository.                                                                                                                                              |
 | `password`              |          | `"postgres"`                                                                     | The password for the postgres user in de database, currently only works with host mode.                                                                                                               |
 
@@ -118,20 +118,16 @@ Builds and deploys a component image.
 
 ## Inputs
 
-| name                  | required | default           | description                                                     |
-| --------------------- | -------- | ----------------- | --------------------------------------------------------------- |
-| `component`           |          | Current component | Component name to build the image for                           |
-| `docker-hub-user`     | ✅       |                   | Username for Docker Hub                                         |
-| `docker-hub-password` | ✅       |                   | Password for Docker Hub                                         |
-| `ghcr-user`           |          | `github.actor`    | Username for GitHub Container Registry                          |
-| `ghcr-password`       |          | `github.token`    | Password for GitHub Container Registry                          |
-| `dockerfile`          |          | `"./Dockerfile"`  | Path to the Dockerfile                                          |
-| `gh-token`            |          | `github.token`    | The github token to delete image tags (only for 'delete' event) |
-
-### `dry-run`
-
-**Optional**  
-Do not deploy build artefacts when set to true
+| name                  | required | default           | description                                                                                      |
+| --------------------- | -------- | ----------------- | ------------------------------------------------------------------------------------------------ |
+| `component`           |          | Current component | Component name to build the image for                                                            |
+| `docker-hub-user`     | ✅       |                   | Username for Docker Hub                                                                          |
+| `docker-hub-password` | ✅       |                   | Password for Docker Hub                                                                          |
+| `ghcr-user`           |          | `github.actor`    | Username for GitHub Container Registry                                                           |
+| `ghcr-password`       |          | `github.token`    | Password for GitHub Container Registry                                                           |
+| `dockerfile`          |          | `"./Dockerfile"`  | Path to the Dockerfile                                                                           |
+| `dry-run`             |          | `false`           | Do not deploy build artefacts when set to `true`                                                 |
+| `gh-token`            |          | `github.token`    | The github token to delete image tags (only for 'delete' event), must have `packages:read` scope |
 
 # `get-artefacts`
 
@@ -163,8 +159,8 @@ _build/{component}/{sha}[/{platform}][/{prefix}]_ prefix.
 | `prefix`                |          |                                                                                                 | If specified, download artefacts from this prefix (appended after platform prefix if specified). |
 | `path`                  |          | `"../{component}/build"`                                                                        | Put artefacts in this path                                                                       |
 | `auto-unzip`            |          | `true`                                                                                          | Automatically unzip artefact files                                                               |
-| `aws-access-key-id`     |          | `env.AWS_ACCESS_KEY_ID`                                                                         | The AWS access key ID                                                                            |
-| `aws-secret-access-key` |          | `env.AWS_SECRET_ACCESS_KEY`                                                                     | The AWS secret access key                                                                        |
+| `aws-access-key-id`     | ✅       |                                                                                                 | The AWS access key ID                                                                            |
+| `aws-secret-access-key` | ✅       |                                                                                                 | The AWS secret access key                                                                        |
 | `gh-token`              |          | `github.token`                                                                                  | A GitHub token with access to the exivity/{component} repository.                                |
 
 # `init-ssh`
@@ -253,14 +249,14 @@ _build/{component}/{sha}[/{platform}][/{prefix}]_ prefix.
 
 ## Inputs
 
-| name                    | required | default                     | description                                                                                    |
-| ----------------------- | -------- | --------------------------- | ---------------------------------------------------------------------------------------------- |
-| `use-platform-prefix`   |          | `false`                     | If `true`, uses `windows` or `linux` prefix depending on current os.                           |
-| `prefix`                |          |                             | If specified, upload artefacts with this prefix (appended after platform prefix if specified). |
-| `path`                  |          | `"build"`                   | Upload artefacts from this path.                                                               |
-| `zip`                   |          | `false`                     | Zip artefact files before uploading as `{component_name}.tar.gz`                               |
-| `aws-access-key-id`     |          | `env.AWS_ACCESS_KEY_ID`     | The AWS access key ID                                                                          |
-| `aws-secret-access-key` |          | `env.AWS_SECRET_ACCESS_KEY` | The AWS secret access key                                                                      |
+| name                    | required | default   | description                                                                                    |
+| ----------------------- | -------- | --------- | ---------------------------------------------------------------------------------------------- |
+| `use-platform-prefix`   |          | `false`   | If `true`, uses `windows` or `linux` prefix depending on current os.                           |
+| `prefix`                |          |           | If specified, upload artefacts with this prefix (appended after platform prefix if specified). |
+| `path`                  |          | `"build"` | Upload artefacts from this path.                                                               |
+| `zip`                   |          | `false`   | Zip artefact files before uploading as `{component_name}.tar.gz`                               |
+| `aws-access-key-id`     | ✅       |           | The AWS access key ID                                                                          |
+| `aws-secret-access-key` | ✅       |           | The AWS secret access key                                                                      |
 
 # `rabbitmq`
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ usage.
 
 ## Inputs
 
-| name              | required | default            | description                                                                                                                                                                                                                                  |
-| ----------------- | -------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `scaffold-branch` |          | `"develop"`        | The scaffold branch to build.                                                                                                                                                                                                                |
-| `gh-token`        |          | `env.GITHUB_TOKEN` | A GitHub token with access to the exivity/scaffold repository.                                                                                                                                                                               |
-| `dry-run`         |          | `false`            | If `true`, scaffold will not build or run any tests.                                                                                                                                                                                         |
-| `filter`          |          |                    | If provided, only trigger acceptance tests if files which match this input are modified. Glob patterns allowed. Multiple entries eparated by newline. If provided, and changed files do not match, writes a successful status to the commit. |
+| name              | required | default        | description                                                                                                                                                                                                                                  |
+| ----------------- | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scaffold-branch` |          | `"develop"`    | The scaffold branch to build.                                                                                                                                                                                                                |
+| `gh-token`        |          | `github.token` | A GitHub token with access to the exivity/scaffold repository.                                                                                                                                                                               |
+| `dry-run`         |          | `false`        | If `true`, scaffold will not build or run any tests.                                                                                                                                                                                         |
+| `filter`          |          |                | If provided, only trigger acceptance tests if files which match this input are modified. Glob patterns allowed. Multiple entries eparated by newline. If provided, and changed files do not match, writes a successful status to the commit. |
 
 # `commit-status`
 
@@ -64,15 +64,15 @@ Writes a [commit status](https://docs.github.com/en/rest/reference/commits#commi
 
 ## Inputs
 
-| name          | required | default            | description                                                                         |
-| ------------- | -------- | ------------------ | ----------------------------------------------------------------------------------- |
-| `component`   |          | Current component  | Component to write the commit status for.                                           |
-| `sha`         |          | Current sha        | Sha of commit to write the status for.                                              |
-| `gh-token`    |          | `env.GITHUB_TOKEN` | A GitHub token with write access to the component.                                  |
-| `state`       |          | `"success"`        | The commit status state, can be `"error"`, `"failure"`, `"pending"` or `"success"`. |
-| `context`     | ✅       |                    | A string label to differentiate this status from the status of other systems.       |
-| `description` |          |                    | A short description of the status.                                                  |
-| `target_url`  |          |                    | The target URL to associate with this status.                                       |
+| name          | required | default           | description                                                                         |
+| ------------- | -------- | ----------------- | ----------------------------------------------------------------------------------- |
+| `component`   |          | Current component | Component to write the commit status for.                                           |
+| `sha`         |          | Current sha       | Sha of commit to write the status for.                                              |
+| `gh-token`    |          | `github.token`    | A GitHub token with write access to the component.                                  |
+| `state`       |          | `"success"`       | The commit status state, can be `"error"`, `"failure"`, `"pending"` or `"success"`. |
+| `context`     | ✅       |                   | A string label to differentiate this status from the status of other systems.       |
+| `description` |          |                   | A short description of the status.                                                  |
+| `target_url`  |          |                   | The target URL to associate with this status.                                       |
 
 # `db`
 
@@ -87,6 +87,7 @@ repository migrations and runs them.
     branch: some-feature-branch
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    gh-token: ${{ secrets.GH_BOT_TOKEN }}
 ```
 
 ## Inputs
@@ -99,7 +100,7 @@ repository migrations and runs them.
 | `version`               |          | `"14.0"`                                                                         | The PostgreSQL version to use. Only affects Docker mode (host mode always uses default version). Make sure to use a string type to avoid truncation. Available versions: `"14.0"`, `"13.0"`, `"12.3"` |
 | `aws-access-key-id`     |          | `env.AWS_ACCESS_KEY_ID`                                                          | The AWS access key ID                                                                                                                                                                                 |
 | `aws-secret-access-key` |          | `env.AWS_SECRET_ACCESS_KEY`                                                      | The AWS secret access key                                                                                                                                                                             |
-| `gh-token`              |          | `env.GITHUB_TOKEN`                                                               | A GitHub token with access to the exivity/db repository.                                                                                                                                              |
+| `gh-token`              |          | `github.token`                                                                   | A GitHub token with access to the exivity/db repository.                                                                                                                                              |
 | `password`              |          | `"postgres"`                                                                     | The password for the postgres user in de database, currently only works with host mode.                                                                                                               |
 
 # `deploy-image`
@@ -117,15 +118,15 @@ Builds and deploys a component image.
 
 ## Inputs
 
-| name                  | required | default            | description                                                     |
-| --------------------- | -------- | ------------------ | --------------------------------------------------------------- |
-| `component`           |          | Current component  | Component name to build the image for                           |
-| `docker-hub-user`     | ✅       |                    | Username for Docker Hub                                         |
-| `docker-hub-password` | ✅       |                    | Password for Docker Hub                                         |
-| `ghcr-user`           |          | `github.actor`     | Username for GitHub Container Registry                          |
-| `ghcr-password`       |          | `env.GITHUB_TOKEN` | Password for GitHub Container Registry                          |
-| `dockerfile`          |          | `"./Dockerfile"`   | Path to the Dockerfile                                          |
-| `gh-token`            |          | `env.GITHUB_TOKEN` | The github token to delete image tags (only for 'delete' event) |
+| name                  | required | default           | description                                                     |
+| --------------------- | -------- | ----------------- | --------------------------------------------------------------- |
+| `component`           |          | Current component | Component name to build the image for                           |
+| `docker-hub-user`     | ✅       |                   | Username for Docker Hub                                         |
+| `docker-hub-password` | ✅       |                   | Password for Docker Hub                                         |
+| `ghcr-user`           |          | `github.actor`    | Username for GitHub Container Registry                          |
+| `ghcr-password`       |          | `github.token`    | Password for GitHub Container Registry                          |
+| `dockerfile`          |          | `"./Dockerfile"`  | Path to the Dockerfile                                          |
+| `gh-token`            |          | `github.token`    | The github token to delete image tags (only for 'delete' event) |
 
 ### `dry-run`
 
@@ -148,7 +149,7 @@ _build/{component}/{sha}[/{platform}][/{prefix}]_ prefix.
     path: db-artefacts
     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    gh-token: ${{ secrets.GITHUB_TOKEN }}
+    gh-token: ${{ secrets.GH_BOT_TOKEN }}
 ```
 
 ## Inputs
@@ -164,7 +165,7 @@ _build/{component}/{sha}[/{platform}][/{prefix}]_ prefix.
 | `auto-unzip`            |          | `true`                                                                                          | Automatically unzip artefact files                                                               |
 | `aws-access-key-id`     |          | `env.AWS_ACCESS_KEY_ID`                                                                         | The AWS access key ID                                                                            |
 | `aws-secret-access-key` |          | `env.AWS_SECRET_ACCESS_KEY`                                                                     | The AWS secret access key                                                                        |
-| `gh-token`              |          | `env.GITHUB_TOKEN`                                                                              | A GitHub token with access to the exivity/{component} repository.                                |
+| `gh-token`              |          | `github.token`                                                                                  | A GitHub token with access to the exivity/{component} repository.                                |
 
 # `init-ssh`
 
@@ -228,7 +229,6 @@ A composite action running [`rcedit`](#rcedit), [`sign-file`](#sign-file) and
     certificate-base64: ${{ secrets.CODESIGN_CERTIFICATE_BASE64 }}
     certificate-password: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
     virustotal-api-key: ${{ secrets.VIRUSTOTAL_API_KEY }}
-    gh-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs
@@ -333,7 +333,7 @@ Reviews a PR.
 | ----------- | -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `component` |          | Current component                     | The component to review a PR for.                                                                                         |
 | `pull`      |          | Latest pull request of current branch | PR number to review.                                                                                                      |
-| `gh-token`  |          | `env.GITHUB_TOKEN`                    | A GitHub token from the PR reviewer.                                                                                      |
+| `gh-token`  |          | `github.token`                        | A GitHub token from the PR reviewer.                                                                                      |
 | `event`     |          | `"APPROVE"`                           | Choose from `"APPROVE"`, `"REQUEST_CHANGES"`, `"COMMENT"` or `"PENDING"`.                                                 |
 | `body`      | Maybe    |                                       | The body of the review text, required when using `"REQUEST_CHANGES"` or `"COMMENT"`.                                      |
 | `branch`    |          | Current branch                        | The head branch the pull request belongs to in order to get latest pull request, not needed if `pull` has been specified. |
@@ -352,15 +352,13 @@ _Based on original work from [amannn/action-semantic-pull-request](https://githu
 
 ```yaml
 - uses: exivity/actions/semantic-pull-request@main
-  with:
-    gh-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs
 
-| name       | required | default            | description                                     |
-| ---------- | -------- | ------------------ | ----------------------------------------------- |
-| `gh-token` |          | `env.GITHUB_TOKEN` | GitHub token with read access to the repository |
+| name       | required | default        | description                                     |
+| ---------- | -------- | -------------- | ----------------------------------------------- |
+| `gh-token` |          | `github.token` | GitHub token with read access to the repository |
 
 # `sign-file`
 
@@ -400,18 +398,18 @@ available).
   with:
     status: ${{ job.status }}
     slack-api-token: ${{ secrets.SLACK_BOT_TOKEN }}
-    gh-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs
 
-| name              | required | default            | description                                                                                                                                                                      |
-| ----------------- | -------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `message`         | Maybe    |                    | The message body to send, markdown is supported. Requid when `status` is not set.                                                                                                |
-| `status`          |          |                    | Include a status message if set to `"success"`, `"failure"` or `"cancelled"`                                                                                                     |
-| `channel`         |          |                    | If provided, send message to this channel instead of commit author. Can be a channel ID, user ID, channel name as `"#channel-name"` or a users display name as `"@display-name"` |
-| `slack-api-token` | ✅       |                    | Slack API token                                                                                                                                                                  |
-| `gh-token`        |          | `env.GITHUB_TOKEN` | GitHub token with read access to the repository                                                                                                                                  |
+| name               | required | default        | description                                                                                                                                                                      |
+| ------------------ | -------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `message`          | Maybe    |                | The message body to send, markdown is supported. Requid when `status` is not set.                                                                                                |
+| `status`           |          |                | Include a status message if set to `"success"`, `"failure"` or `"cancelled"`                                                                                                     |
+| `channel`          |          |                | If provided, send message to this channel instead of commit author. Can be a channel ID, user ID, channel name as `"#channel-name"` or a users display name as `"@display-name"` |
+| `fallback-channel` |          | `"#builds"`    | If a Slack user can't be resolved, use this channel as a fallback.                                                                                                               |
+| `slack-api-token`  | ✅       |                | Slack API token                                                                                                                                                                  |
+| `gh-token`         |          | `github.token` | GitHub token with read access to the repository                                                                                                                                  |
 
 # `virustotal`
 
@@ -428,7 +426,6 @@ Build workflow:
   with:
     path: build/foo.exe
     virustotal-api-key: ${{ secrets.VIRUSTOTAL_API_KEY }}
-    gh-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 Separate check workflow:
@@ -449,17 +446,16 @@ jobs:
         with:
           mode: check
           virustotal-api-key: ${{ secrets.VIRUSTOTAL_API_KEY }}
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Inputs
 
-| name                 | required | default            | description                                                                                         |
-| -------------------- | -------- | ------------------ | --------------------------------------------------------------------------------------------------- |
-| `mode`               |          | `"analyse"`        | Whether to analyse artefacts or check the analysis status. Either `"analyse"` or `"check"`.         |
-| `path`               | Maybe    |                    | The path to the file to analyse, glob patterns allowed. Required when `mode` is set to `"analyse"`. |
-| `virustotal-api-key` | ✅       |                    | The VirusTotal API key                                                                              |
-| `gh-token`           |          | `env.GITHUB_TOKEN` | GitHub token used for writing commit status                                                         |
+| name                 | required | default        | description                                                                                         |
+| -------------------- | -------- | -------------- | --------------------------------------------------------------------------------------------------- |
+| `mode`               |          | `"analyse"`    | Whether to analyse artefacts or check the analysis status. Either `"analyse"` or `"check"`.         |
+| `path`               | Maybe    |                | The path to the file to analyse, glob patterns allowed. Required when `mode` is set to `"analyse"`. |
+| `virustotal-api-key` | ✅       |                | The VirusTotal API key                                                                              |
+| `gh-token`           |          | `github.token` | GitHub token used for writing commit status                                                         |
 
 # Development guide
 

--- a/accept/action.yml
+++ b/accept/action.yml
@@ -7,6 +7,7 @@ inputs:
   gh-token:
     description: A GitHub token
     required: false
+    default: ${{ github.token }}
   dry-run:
     description: Run scaffold in dry-run mode
     required: false

--- a/accept/dist/index.js
+++ b/accept/dist/index.js
@@ -29465,7 +29465,7 @@ function getWorkspacePath() {
   return workspacePath;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core2.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core2.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }

--- a/commit-status/action.yml
+++ b/commit-status/action.yml
@@ -10,6 +10,7 @@ inputs:
   gh-token:
     description: A GitHub token with write access to the component
     required: false
+    default: ${{ github.token }}
   state:
     description: The commit status state, can be "error", "failure", "pending" or "success"
     required: true

--- a/commit-status/dist/index.js
+++ b/commit-status/dist/index.js
@@ -6832,7 +6832,7 @@ async function getSha() {
   return sha;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }

--- a/db/action.yml
+++ b/db/action.yml
@@ -22,6 +22,7 @@ inputs:
   gh-token:
     description: 'A GitHub token'
     required: false
+    default: ${{ github.token }}
   password:
     description: 'The password of the postgres user, only works with host mode'
     required: false

--- a/db/dist/index.js
+++ b/db/dist/index.js
@@ -7922,7 +7922,7 @@ function getWorkspacePath() {
   return workspacePath;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core2.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core2.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }
@@ -7980,8 +7980,8 @@ async function downloadS3object({
   });
 }
 function getAWSCredentials() {
-  const awsKeyId = (0, import_core3.getInput)("aws-access-key-id") || process.env["AWS_ACCESS_KEY_ID"];
-  const awsSecretKey = (0, import_core3.getInput)("aws-secret-access-key") || process.env["AWS_SECRET_ACCESS_KEY"];
+  const awsKeyId = (0, import_core3.getInput)("aws-access-key-id");
+  const awsSecretKey = (0, import_core3.getInput)("aws-secret-access-key");
   if (!awsKeyId || !awsSecretKey) {
     throw new Error("A required AWS input is missing");
   }

--- a/deploy-image/action.yml
+++ b/deploy-image/action.yml
@@ -16,12 +16,14 @@ inputs:
   ghcr-password:
     description: Password for GitHub Container Registry
     required: false
+    default: ${{ github.token }}
   dockerfile:
     description: Path to the Dockerfile, defaults to ./Dockerfile
     required: false
   gh-token:
     description: The github token to delete image tags (only for 'delete' event)
     required: false
+    default: ${{ github.token }}
   dry-run:
     description: Do not deploy build artefacts
     required: false

--- a/deploy-image/dist/index.js
+++ b/deploy-image/dist/index.js
@@ -10182,7 +10182,7 @@ function getTag() {
   return ((_a = process.env["GITHUB_REF"]) == null ? void 0 : _a.slice(0, 10)) == "refs/tags/" ? (_b = process.env["GITHUB_REF"]) == null ? void 0 : _b.slice(10) : null;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core2.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core2.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }

--- a/dummy-data/action.yml
+++ b/dummy-data/action.yml
@@ -4,6 +4,7 @@ inputs:
   gh-token:
     description: 'The github token to pull dummy-data with'
     required: false
+    default: ${{ github.token }}
   seed:
     description: 'A seed for the random number generator used by the fake data generator'
     required: false

--- a/dummy-data/dist/index.js
+++ b/dummy-data/dist/index.js
@@ -7913,7 +7913,7 @@ function getWorkspacePath() {
   return workspacePath;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core2.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core2.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }
@@ -7954,8 +7954,8 @@ async function downloadS3object({
   });
 }
 function getAWSCredentials() {
-  const awsKeyId = (0, import_core3.getInput)("aws-access-key-id") || process.env["AWS_ACCESS_KEY_ID"];
-  const awsSecretKey = (0, import_core3.getInput)("aws-secret-access-key") || process.env["AWS_SECRET_ACCESS_KEY"];
+  const awsKeyId = (0, import_core3.getInput)("aws-access-key-id");
+  const awsSecretKey = (0, import_core3.getInput)("aws-secret-access-key");
   if (!awsKeyId || !awsSecretKey) {
     throw new Error("A required AWS input is missing");
   }

--- a/get-artefacts/action.yml
+++ b/get-artefacts/action.yml
@@ -31,6 +31,7 @@ inputs:
   gh-token:
     description: 'A GitHub token'
     required: false
+    default: ${{ github.token }}
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/get-artefacts/dist/index.js
+++ b/get-artefacts/dist/index.js
@@ -7921,7 +7921,7 @@ function getWorkspacePath() {
   return workspacePath;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core2.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core2.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }
@@ -7962,8 +7962,8 @@ async function downloadS3object({
   });
 }
 function getAWSCredentials() {
-  const awsKeyId = (0, import_core3.getInput)("aws-access-key-id") || process.env["AWS_ACCESS_KEY_ID"];
-  const awsSecretKey = (0, import_core3.getInput)("aws-secret-access-key") || process.env["AWS_SECRET_ACCESS_KEY"];
+  const awsKeyId = (0, import_core3.getInput)("aws-access-key-id");
+  const awsSecretKey = (0, import_core3.getInput)("aws-secret-access-key");
   if (!awsKeyId || !awsSecretKey) {
     throw new Error("A required AWS input is missing");
   }

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -8,10 +8,10 @@ export async function getCommitMessage() {
   return execGit('git log -1 --pretty=format:"%s"')
 }
 
-export async function getCommitAuthor() {
+export async function getCommitAuthorName() {
   return execGit('git log -1 --pretty=format:"%an"')
 }
 
-export async function getCommitEmail() {
+export async function getCommitAuthorEmail() {
   return execGit('git log -1 --pretty=format:"%ae"')
 }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -146,7 +146,7 @@ export function getWorkspacePath() {
 }
 
 export function getToken(inputName = 'gh-token') {
-  const ghToken = getInput(inputName) || process.env['GITHUB_TOKEN']
+  const ghToken = getInput(inputName)
 
   if (!ghToken) {
     throw new Error('The GitHub token is missing')

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -1,4 +1,4 @@
-import { info, getInput } from '@actions/core'
+import { getInput, info } from '@actions/core'
 import { exec } from '@actions/exec'
 import { promises as fsPromises } from 'fs'
 import { platform } from 'os'
@@ -97,10 +97,8 @@ export async function uploadS3object({
 }
 
 export function getAWSCredentials() {
-  const awsKeyId =
-    getInput('aws-access-key-id') || process.env['AWS_ACCESS_KEY_ID']
-  const awsSecretKey =
-    getInput('aws-secret-access-key') || process.env['AWS_SECRET_ACCESS_KEY']
+  const awsKeyId = getInput('aws-access-key-id')
+  const awsSecretKey = getInput('aws-secret-access-key')
 
   // Assertions
   if (!awsKeyId || !awsSecretKey) {

--- a/process-binary/action.yml
+++ b/process-binary/action.yml
@@ -16,6 +16,7 @@ inputs:
   gh-token:
     description: GitHub token used for writing commit status
     required: false
+    default: ${{ github.token }}
 runs:
   using: 'composite'
   steps:

--- a/put-artefacts/action.yml
+++ b/put-artefacts/action.yml
@@ -22,6 +22,7 @@ inputs:
   gh-token:
     description: 'A GitHub token'
     required: false
+    default: ${{ github.token }}
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/put-artefacts/dist/index.js
+++ b/put-artefacts/dist/index.js
@@ -2481,8 +2481,8 @@ async function uploadS3object({
   });
 }
 function getAWSCredentials() {
-  const awsKeyId = (0, import_core3.getInput)("aws-access-key-id") || process.env["AWS_ACCESS_KEY_ID"];
-  const awsSecretKey = (0, import_core3.getInput)("aws-secret-access-key") || process.env["AWS_SECRET_ACCESS_KEY"];
+  const awsKeyId = (0, import_core3.getInput)("aws-access-key-id");
+  const awsSecretKey = (0, import_core3.getInput)("aws-secret-access-key");
   if (!awsKeyId || !awsSecretKey) {
     throw new Error("A required AWS input is missing");
   }

--- a/review/action.yml
+++ b/review/action.yml
@@ -10,6 +10,7 @@ inputs:
   gh-token:
     description: 'A GitHub token from the PR reviewer'
     required: false
+    default: ${{ github.token }}
   event:
     description: 'What to do, defaults to APPROVE, other options are REQUEST_CHANGES, COMMENT or PENDING'
     default: 'APPROVE'

--- a/review/dist/index.js
+++ b/review/dist/index.js
@@ -6838,7 +6838,7 @@ function getRef() {
   return ref;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }

--- a/semantic-pull-request/action.yml
+++ b/semantic-pull-request/action.yml
@@ -3,7 +3,8 @@ description: Ensures your pull requests follow the Conventional Commits spec
 inputs:
   gh-token:
     description: GitHub token with read access to the repository
-    required: true
+    required: false
+    default: ${{ github.token }}
 runs:
   using: node16
   main: dist/index.js

--- a/semantic-pull-request/dist/index.js
+++ b/semantic-pull-request/dist/index.js
@@ -6827,7 +6827,7 @@ function getRepository() {
   return { owner, component };
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }

--- a/slack/action.yml
+++ b/slack/action.yml
@@ -10,12 +10,17 @@ inputs:
   channel:
     description: Send message to this channel instead of commit author
     required: false
+  fallback-channel:
+    description: Use this channel as a fallback
+    required: false
+    default: '#builds'
   slack-api-token:
     description: Slack API key
     required: true
   gh-token:
     description: GitHub token with read access to the repository
-    required: true
+    required: false
+    default: ${{ github.token }}
 runs:
   using: node16
   main: dist/index.js

--- a/slack/dist/index.js
+++ b/slack/dist/index.js
@@ -685,12 +685,12 @@ var require_http_client = __commonJS({
           throw new Error("Client has already been disposed.");
         }
         let parsedUrl = new URL(requestUrl);
-        let info3 = this._prepareRequest(verb, parsedUrl, headers);
+        let info4 = this._prepareRequest(verb, parsedUrl, headers);
         let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1 ? this._maxRetries + 1 : 1;
         let numTries = 0;
         let response;
         while (numTries < maxTries) {
-          response = await this.requestRaw(info3, data);
+          response = await this.requestRaw(info4, data);
           if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
             let authenticationHandler;
             for (let i = 0; i < this.handlers.length; i++) {
@@ -700,7 +700,7 @@ var require_http_client = __commonJS({
               }
             }
             if (authenticationHandler) {
-              return authenticationHandler.handleAuthentication(this, info3, data);
+              return authenticationHandler.handleAuthentication(this, info4, data);
             } else {
               return response;
             }
@@ -723,8 +723,8 @@ var require_http_client = __commonJS({
                 }
               }
             }
-            info3 = this._prepareRequest(verb, parsedRedirectUrl, headers);
-            response = await this.requestRaw(info3, data);
+            info4 = this._prepareRequest(verb, parsedRedirectUrl, headers);
+            response = await this.requestRaw(info4, data);
             redirectsRemaining--;
           }
           if (HttpResponseRetryCodes.indexOf(response.message.statusCode) == -1) {
@@ -744,7 +744,7 @@ var require_http_client = __commonJS({
         }
         this._disposed = true;
       }
-      requestRaw(info3, data) {
+      requestRaw(info4, data) {
         return new Promise((resolve, reject) => {
           let callbackForResult = function(err, res) {
             if (err) {
@@ -752,13 +752,13 @@ var require_http_client = __commonJS({
             }
             resolve(res);
           };
-          this.requestRawWithCallback(info3, data, callbackForResult);
+          this.requestRawWithCallback(info4, data, callbackForResult);
         });
       }
-      requestRawWithCallback(info3, data, onResult) {
+      requestRawWithCallback(info4, data, onResult) {
         let socket;
         if (typeof data === "string") {
-          info3.options.headers["Content-Length"] = Buffer.byteLength(data, "utf8");
+          info4.options.headers["Content-Length"] = Buffer.byteLength(data, "utf8");
         }
         let callbackCalled = false;
         let handleResult = (err, res) => {
@@ -767,7 +767,7 @@ var require_http_client = __commonJS({
             onResult(err, res);
           }
         };
-        let req = info3.httpModule.request(info3.options, (msg) => {
+        let req = info4.httpModule.request(info4.options, (msg) => {
           let res = new HttpClientResponse(msg);
           handleResult(null, res);
         });
@@ -778,7 +778,7 @@ var require_http_client = __commonJS({
           if (socket) {
             socket.end();
           }
-          handleResult(new Error("Request timeout: " + info3.options.path), null);
+          handleResult(new Error("Request timeout: " + info4.options.path), null);
         });
         req.on("error", function(err) {
           handleResult(err, null);
@@ -800,27 +800,27 @@ var require_http_client = __commonJS({
         return this._getAgent(parsedUrl);
       }
       _prepareRequest(method, requestUrl, headers) {
-        const info3 = {};
-        info3.parsedUrl = requestUrl;
-        const usingSsl = info3.parsedUrl.protocol === "https:";
-        info3.httpModule = usingSsl ? https : http;
+        const info4 = {};
+        info4.parsedUrl = requestUrl;
+        const usingSsl = info4.parsedUrl.protocol === "https:";
+        info4.httpModule = usingSsl ? https : http;
         const defaultPort = usingSsl ? 443 : 80;
-        info3.options = {};
-        info3.options.host = info3.parsedUrl.hostname;
-        info3.options.port = info3.parsedUrl.port ? parseInt(info3.parsedUrl.port) : defaultPort;
-        info3.options.path = (info3.parsedUrl.pathname || "") + (info3.parsedUrl.search || "");
-        info3.options.method = method;
-        info3.options.headers = this._mergeHeaders(headers);
+        info4.options = {};
+        info4.options.host = info4.parsedUrl.hostname;
+        info4.options.port = info4.parsedUrl.port ? parseInt(info4.parsedUrl.port) : defaultPort;
+        info4.options.path = (info4.parsedUrl.pathname || "") + (info4.parsedUrl.search || "");
+        info4.options.method = method;
+        info4.options.headers = this._mergeHeaders(headers);
         if (this.userAgent != null) {
-          info3.options.headers["user-agent"] = this.userAgent;
+          info4.options.headers["user-agent"] = this.userAgent;
         }
-        info3.options.agent = this._getAgent(info3.parsedUrl);
+        info4.options.agent = this._getAgent(info4.parsedUrl);
         if (this.handlers) {
           this.handlers.forEach((handler) => {
-            handler.prepareRequest(info3.options);
+            handler.prepareRequest(info4.options);
           });
         }
-        return info3;
+        return info4;
       }
       _mergeHeaders(headers) {
         const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
@@ -1261,18 +1261,18 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       command_1.issueCommand("error", utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
     }
     exports.error = error;
-    function warning2(message, properties = {}) {
+    function warning3(message, properties = {}) {
       command_1.issueCommand("warning", utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
     }
-    exports.warning = warning2;
+    exports.warning = warning3;
     function notice(message, properties = {}) {
       command_1.issueCommand("notice", utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
     }
     exports.notice = notice;
-    function info3(message) {
+    function info4(message) {
       process.stdout.write(message + os.EOL);
     }
-    exports.info = info3;
+    exports.info = info4;
     function startGroup(name) {
       command_1.issue("group", name);
     }
@@ -7868,10 +7868,10 @@ async function execGit(command, silent = true) {
 async function getCommitMessage() {
   return execGit('git log -1 --pretty=format:"%s"');
 }
-async function getCommitAuthor() {
+async function getCommitAuthorName() {
   return execGit('git log -1 --pretty=format:"%an"');
 }
-async function getCommitEmail() {
+async function getCommitAuthorEmail() {
   return execGit('git log -1 --pretty=format:"%ae"');
 }
 
@@ -8018,9 +8018,9 @@ ${JSON.stringify(error, void 0, 2)}`);
       throw new Error("Could not retrieve Slack users");
     }
   }
-  async resolveChannelToUserId(value) {
+  async resolveChannelId(value) {
     if (value.startsWith("@")) {
-      (0, import_core2.debug)(`Trying to resolve user ${value}`);
+      (0, import_core2.info)(`Trying to resolve user ${value}...`);
       const users = await this.usersList({
         limit: 1e3
       });
@@ -8028,7 +8028,7 @@ ${JSON.stringify(error, void 0, 2)}`);
       return (userMatch == null ? void 0 : userMatch.id) || null;
     }
     if (value.startsWith("#")) {
-      (0, import_core2.debug)(`Trying to resolve channel ${value}`);
+      (0, import_core2.info)(`Trying to resolve channel ${value}`);
       const channels = await this.conversationsList({
         exclude_archived: false,
         limit: 1e3,
@@ -8063,7 +8063,8 @@ async function run() {
   });
   const token = getToken();
   const ref = getRef();
-  let userProvidedChannel = (0, import_core3.getInput)("channel") || null;
+  const userProvidedChannel = (0, import_core3.getInput)("channel") || null;
+  const fallbackChannel = (0, import_core3.getInput)("fallback-channel") || null;
   let channel = null;
   if (!isValidStatus(status)) {
     throw new Error("The status input is invalid");
@@ -8074,14 +8075,26 @@ async function run() {
   const slack = new Slack(slackApiToken);
   const octokit = (0, import_github.getOctokit)(token);
   const commitMessage = await getCommitMessage();
-  const author = await getCommitAuthor();
-  const email = await getCommitEmail();
+  const authorName = await getCommitAuthorName();
+  const authorEmail = await getCommitAuthorEmail();
   const pr = await getPrFromRef(octokit, component, ref);
-  const user = await slack.findUserFuzzy([author, email, import_github.context.actor]);
+  const user = await slack.findUserFuzzy([
+    authorName,
+    authorEmail,
+    import_github.context.actor
+  ]);
   if (userProvidedChannel) {
-    channel = await slack.resolveChannelToUserId(userProvidedChannel);
+    channel = await slack.resolveChannelId(userProvidedChannel);
   } else if (user) {
     channel = user.id;
+  }
+  if (!channel) {
+    (0, import_core3.warning)(`Please set the "channel" input or make sure this action can match the author of the commit triggering this workflow to a Slack user (tried with "${authorName}", "${authorEmail}" and "${import_github.context.action}").`);
+    (0, import_console.info)(`This action will try to match the author of the commit using the Slack user attributes "name", "display_name", "real_name" or "email".`);
+    if (fallbackChannel) {
+      (0, import_console.info)(`Using fallback channel "${fallbackChannel}"`);
+      channel = await slack.resolveChannelId(fallbackChannel);
+    }
   }
   if (!channel) {
     throw new Error(`Could not find a channel to send the message to`);

--- a/slack/dist/index.js
+++ b/slack/dist/index.js
@@ -7917,7 +7917,7 @@ function getRef() {
   return ref;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }

--- a/slack/src/slack.ts
+++ b/slack/src/slack.ts
@@ -1,4 +1,4 @@
-import { debug } from '@actions/core'
+import { debug, info } from '@actions/core'
 import { HttpClient } from '@actions/http-client'
 import { ITypedResponse } from '@actions/http-client/interfaces'
 import { Blocks } from './types'
@@ -236,10 +236,10 @@ export class Slack {
     }
   }
 
-  async resolveChannelToUserId(value: string) {
+  async resolveChannelId(value: string) {
     if (value.startsWith('@')) {
       // Search for a user
-      debug(`Trying to resolve user ${value}`)
+      info(`Trying to resolve user ${value}...`)
       const users = await this.usersList({
         limit: 1000,
       })
@@ -249,7 +249,7 @@ export class Slack {
 
     if (value.startsWith('#')) {
       // Search for a channel
-      debug(`Trying to resolve channel ${value}`)
+      info(`Trying to resolve channel ${value}`)
       const channels = await this.conversationsList({
         exclude_archived: false,
         limit: 1000,

--- a/virustotal/action.yml
+++ b/virustotal/action.yml
@@ -13,6 +13,7 @@ inputs:
   gh-token:
     description: GitHub token used for writing commit status
     required: false
+    default: ${{ github.token }}
 runs:
   using: node16
   main: dist/index.js

--- a/virustotal/dist/index.js
+++ b/virustotal/dist/index.js
@@ -18603,7 +18603,7 @@ function getRef() {
   return ref;
 }
 function getToken(inputName = "gh-token") {
-  const ghToken = (0, import_core.getInput)(inputName) || process.env["GITHUB_TOKEN"];
+  const ghToken = (0, import_core.getInput)(inputName);
   if (!ghToken) {
     throw new Error("The GitHub token is missing");
   }


### PR DESCRIPTION
Adds a `fallback-channel` input to the slack action and defaults for the `gh-token` input. Also remove the `env.*` defaults for inputs for security reasons. This is a breaking change.
