### PR TITLE
chore: Add buildArgs option for Docker build

### DIFF
--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: Pass the SSH agent to the build context
     required: false
     default: 'false'
+  buildArgs:
+    description: Build arguments for Docker build
+    required: false
+    default: ''
 runs:
   using: node20
   main: dist/index.js

--- a/build-push-image/src/index.ts
+++ b/build-push-image/src/index.ts
@@ -10,6 +10,16 @@ import { getOwnerInput, getRepoInput } from '../../lib/github'
 import { branchToTag, getLabels } from '../../lib/image'
 import { writeMetadataFile } from './metadataFile'
 
+function parseBuildArgs(buildArgsStr: string): Record<string, string> {
+  const buildArgs: Record<string, string> = {}
+  const pairs = buildArgsStr.split(',')
+  pairs.forEach(pair => {
+    const [key, value] = pair.split('=')
+    buildArgs[key] = value
+  })
+  return buildArgs
+}
+
 async function run() {
   // Inputs
   const namespace = getOwnerInput('namespace')
@@ -20,6 +30,8 @@ async function run() {
   const user = getInput('user')
   const password = getInput('password')
   const useSSH = getBooleanInput('useSSH')
+  const buildArgsStr = getInput('buildArgs')
+  const buildArgs = parseBuildArgs(buildArgsStr)
 
   // Get all relevant metadata for the image
   const labels = getLabels(name)
@@ -44,6 +56,7 @@ async function run() {
     labels,
     image,
     useSSH,
+    buildArgs,
   })
 
   await dockerPush(image)

--- a/lib/dockerCli.ts
+++ b/lib/dockerCli.ts
@@ -30,6 +30,7 @@ type BuildOptions = {
   labels: { [key: string]: string }
   image: Image
   useSSH: boolean
+  buildArgs: Record<string, string>
 }
 
 export type Image = {
@@ -45,6 +46,7 @@ export async function dockerBuild({
   labels,
   image,
   useSSH,
+  buildArgs, // Add buildArgs to function parameters
 }: BuildOptions) {
   info('Building image...')
 
@@ -53,11 +55,16 @@ export async function dockerBuild({
     .map(([key, value]) => `--label "${key}=${value}"`)
     .join(' ')
 
+  // Concat list of build args
+  const buildArgsOptions = Object.entries(buildArgs)
+    .map(([key, value]) => `--build-arg ${key}=${value}`)
+    .join(' ')
+
   const ssh = useSSH ? '--ssh default' : ''
 
   const cmd = `/usr/bin/bash -c "docker build ${ssh} -f ${dockerfile} -t ${getImageFQN(
     image,
-  )} ${labelOptions} ${context}"`
+  )} ${labelOptions} ${buildArgsOptions} ${context}"`
   debug(`Executing command:\n${cmd}`)
 
   await exec(cmd, undefined, {


### PR DESCRIPTION
This pull request adds a new option, `buildArgs`, for the Docker build process. The `buildArgs` option allows users to specify build arguments for the Docker build command. This feature enhances the flexibility and customization of the build process.