### PR TITLE
chore: Add support for Docker build platform option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,17 @@ needed.
 
 ## Inputs
 
-| name         | required | default          | description                                                                   |
-| ------------ | -------- | ---------------- | ----------------------------------------------------------------------------- |
-| `namespace`  |          | Repository owner | The namespace of the image repository                                         |
-| `name`       |          | Repository name  | The name of the image repository                                              |
-| `dockerfile` |          | `"./Dockerfile"` | Path to the Dockerfile                                                        |
-| `registry`   |          | `"ghcr.io"`      | Registry to use, e.g. `"ghcr.io"` (default) or `"docker.io"` (for Docker Hub) |
-| `user`       |          | `github.actor`   | Username for the Docker registry                                              |
-| `password`   |          | `github.token`   | Password for the Docker registry                                              |
-| `useSSH`     | false    | `false`          | Whether to use SSH for Git operations                                         |
-| `secrets`    | false    |                  | Secrets for Docker build like `id=npmrc,src=$HOME/.npmrc`                     |
+| name         | required | default                                | description                                                                   |
+| ------------ | -------- | -------------------------------------- | ----------------------------------------------------------------------------- |
+| `namespace`  |          | Repository owner                       | The namespace of the image repository                                         |
+| `name`       |          | Repository name                        | The name of the image repository                                              |
+| `dockerfile` |          | `"./Dockerfile"`                       | Path to the Dockerfile                                                        |
+| `registry`   |          | `"ghcr.io"`                            | Registry to use, e.g. `"ghcr.io"` (default) or `"docker.io"` (for Docker Hub) |
+| `user`       |          | `github.actor`                         | Username for the Docker registry                                              |
+| `password`   |          | `github.token`                         | Password for the Docker registry                                              |
+| `useSSH`     | false    | `false`                                | Whether to use SSH for Git operations                                         |
+| `secrets`    | false    |                                        | Secrets for Docker build like `id=npmrc,src=$HOME/.npmrc`                     |
+| `platform`   | false    | 'linux/amd64,linux/arm/v7,linux/arm64' | Platforms for Docker build                                                    |
 
 # `commit-status`
 

--- a/README.md
+++ b/README.md
@@ -53,17 +53,17 @@ needed.
 
 ## Inputs
 
-| name         | required | default                                | description                                                                   |
-| ------------ | -------- | -------------------------------------- | ----------------------------------------------------------------------------- |
-| `namespace`  |          | Repository owner                       | The namespace of the image repository                                         |
-| `name`       |          | Repository name                        | The name of the image repository                                              |
-| `dockerfile` |          | `"./Dockerfile"`                       | Path to the Dockerfile                                                        |
-| `registry`   |          | `"ghcr.io"`                            | Registry to use, e.g. `"ghcr.io"` (default) or `"docker.io"` (for Docker Hub) |
-| `user`       |          | `github.actor`                         | Username for the Docker registry                                              |
-| `password`   |          | `github.token`                         | Password for the Docker registry                                              |
-| `useSSH`     | false    | `false`                                | Whether to use SSH for Git operations                                         |
-| `secrets`    | false    |                                        | Secrets for Docker build like `id=npmrc,src=$HOME/.npmrc`                     |
-| `platform`   | false    | 'linux/amd64,linux/arm/v7,linux/arm64' | Platforms for Docker build                                                    |
+| name         | required | default          | description                                                                   |
+| ------------ | -------- | ---------------- | ----------------------------------------------------------------------------- |
+| `namespace`  |          | Repository owner | The namespace of the image repository                                         |
+| `name`       |          | Repository name  | The name of the image repository                                              |
+| `dockerfile` |          | `"./Dockerfile"` | Path to the Dockerfile                                                        |
+| `registry`   |          | `"ghcr.io"`      | Registry to use, e.g. `"ghcr.io"` (default) or `"docker.io"` (for Docker Hub) |
+| `user`       |          | `github.actor`   | Username for the Docker registry                                              |
+| `password`   |          | `github.token`   | Password for the Docker registry                                              |
+| `useSSH`     | false    | `false`          | Whether to use SSH for Git operations                                         |
+| `secrets`    | false    |                  | Secrets for Docker build like `id=npmrc,src=$HOME/.npmrc`                     |
+| `platform`   | false    |                  | Platforms for Docker build like `'linux/amd64,linux/arm/v7,linux/arm64`       |
 
 # `commit-status`
 

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -40,7 +40,6 @@ inputs:
   platform:
     description: Platforms for Docker build
     required: false
-    default: 'linux/amd64,linux/arm/v7,linux/arm64'
 runs:
   using: node20
   main: dist/index.js

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -37,6 +37,10 @@ inputs:
   secrets:
     description: Secrets for Docker build
     required: false
+  platform:
+    description: Platforms for Docker build
+    required: false
+    default: 'linux/amd64,linux/arm/v7,linux/arm64'
 runs:
   using: node20
   main: dist/index.js

--- a/build-push-image/dist/index.js
+++ b/build-push-image/dist/index.js
@@ -25136,6 +25136,12 @@ async function dockerBuild({
   secrets,
   platform
 }) {
+  (0, import_core2.info)("Install docker buildx...");
+  await (0, import_exec2.exec)(
+    "docker run --rm --privileged multiarch/qemu-user-static --reset -p yes"
+  );
+  await (0, import_exec2.exec)("docker buildx create --name mybuilder --use");
+  await (0, import_exec2.exec)("docker buildx inspect --bootstrap");
   (0, import_core2.info)("Building image...");
   const labelOptions = Object.entries(labels).map(([key, value]) => `--label "${key}=${value}"`).join(" ");
   const ssh = useSSH ? "--ssh default" : "";

--- a/build-push-image/dist/index.js
+++ b/build-push-image/dist/index.js
@@ -25133,13 +25133,15 @@ async function dockerBuild({
   labels,
   image,
   useSSH,
-  secrets
+  secrets,
+  platform
 }) {
   (0, import_core2.info)("Building image...");
   const labelOptions = Object.entries(labels).map(([key, value]) => `--label "${key}=${value}"`).join(" ");
   const ssh = useSSH ? "--ssh default" : "";
   const secretArgs = secrets ? `--secret ${secrets}` : "";
-  const cmd = `/usr/bin/bash -c "docker build ${ssh} ${secretArgs} -f ${dockerfile} -t ${getImageFQN(
+  const platformArgs = platform ? `--platform ${platform}` : "";
+  const cmd = `/usr/bin/bash -c "docker buildx build ${ssh} ${secretArgs} ${platformArgs} -f ${dockerfile} -t ${getImageFQN(
     image
   )} ${labelOptions} ${context2}"`;
   (0, import_core2.debug)(`Executing command:
@@ -25291,6 +25293,7 @@ async function run() {
   const password = (0, import_core5.getInput)("password");
   const useSSH = (0, import_core5.getBooleanInput)("useSSH");
   const secrets = (0, import_core5.getInput)("secrets");
+  const platform = (0, import_core5.getInput)("platform");
   const labels = getLabels(name);
   const tag = branchToTag();
   const image = { registry, namespace, name, tag };
@@ -25309,7 +25312,8 @@ async function run() {
     labels,
     image,
     useSSH,
-    secrets
+    secrets,
+    platform
   });
   await dockerPush(image);
 }

--- a/build-push-image/src/index.ts
+++ b/build-push-image/src/index.ts
@@ -21,6 +21,7 @@ async function run() {
   const password = getInput('password')
   const useSSH = getBooleanInput('useSSH')
   const secrets = getInput('secrets')
+  const platform = getInput('platform')
 
   // Get all relevant metadata for the image
   const labels = getLabels(name)
@@ -46,6 +47,7 @@ async function run() {
     image,
     useSSH,
     secrets,
+    platform,
   })
 
   await dockerPush(image)

--- a/lib/dockerCli.ts
+++ b/lib/dockerCli.ts
@@ -30,6 +30,7 @@ type BuildOptions = {
   labels: { [key: string]: string }
   image: Image
   useSSH: boolean
+  platform: string
 }
 
 export type Image = {
@@ -46,6 +47,7 @@ export async function dockerBuild({
   image,
   useSSH,
   secrets,
+  platform,
 }: BuildOptions & { secrets?: string }) {
   info('Building image...')
 
@@ -56,8 +58,9 @@ export async function dockerBuild({
 
   const ssh = useSSH ? '--ssh default' : ''
   const secretArgs = secrets ? `--secret ${secrets}` : ''
+  const platformArgs = platform ? `--platform ${platform}` : ''
 
-  const cmd = `/usr/bin/bash -c "docker build ${ssh} ${secretArgs} -f ${dockerfile} -t ${getImageFQN(
+  const cmd = `/usr/bin/bash -c "docker buildx build ${ssh} ${secretArgs} ${platformArgs} -f ${dockerfile} -t ${getImageFQN(
     image,
   )} ${labelOptions} ${context}"`
   debug(`Executing command:\n${cmd}`)

--- a/lib/dockerCli.ts
+++ b/lib/dockerCli.ts
@@ -49,6 +49,13 @@ export async function dockerBuild({
   secrets,
   platform,
 }: BuildOptions & { secrets?: string }) {
+  info('Install docker buildx...')
+  await exec(
+    'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',
+  )
+  await exec('docker buildx create --name mybuilder --use')
+  await exec('docker buildx inspect --bootstrap')
+
   info('Building image...')
 
   // Concat list of labels

--- a/lib/dockerCli.ts
+++ b/lib/dockerCli.ts
@@ -30,6 +30,7 @@ type BuildOptions = {
   labels: { [key: string]: string }
   image: Image
   useSSH: boolean
+  secrets: string
   platform: string
 }
 
@@ -48,7 +49,7 @@ export async function dockerBuild({
   useSSH,
   secrets,
   platform,
-}: BuildOptions & { secrets?: string }) {
+}: BuildOptions & {}) {
   info('Install docker buildx...')
   await exec(
     'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes',


### PR DESCRIPTION
This pull request adds support for the Docker build platform option. It allows users to specify the platforms for Docker build, such as 'linux/amd64,linux/arm/v7,linux/arm64'. This feature enhances the flexibility and compatibility of the Docker build process.