### PR TITLE
chore: apply default import instead of named import for mime

### DIFF
--- a/virustotal/src/virustotal.ts
+++ b/virustotal/src/virustotal.ts
@@ -2,7 +2,7 @@ import { debug } from '@actions/core'
 import { HttpClient } from '@actions/http-client'
 import FormData from 'form-data'
 import { createReadStream, lstatSync } from 'fs'
-import { getType } from 'mime'
+import mime from 'mime'
 import { basename } from 'path'
 import { z } from 'zod'
 
@@ -181,5 +181,5 @@ export function asset(path: string) {
 }
 
 export function mimeOrDefault(path: string) {
-  return getType(path) || 'application/octet-stream'
+  return mime.getType(path) || 'application/octet-stream'
 }


### PR DESCRIPTION
Updated `mime` import style to use a default import in this pr.

CLOSE-[EXVT-5941](https://exivity.atlassian.net/browse/EXVT-5941)

[EXVT-5941]: https://exivity.atlassian.net/browse/EXVT-5941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ