### PR TITLE
chore: Update Jira client authentication to use email and API token

### DIFF
--- a/release-notes/dist/index.js
+++ b/release-notes/dist/index.js
@@ -39437,19 +39437,6 @@ var errorUtil;
 })(errorUtil || (errorUtil = {}));
 
 // node_modules/zod/dist/esm/v3/types.js
-var __classPrivateFieldGet = function(receiver, state, kind, f) {
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-  return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
-var __classPrivateFieldSet = function(receiver, state, value, kind, f) {
-  if (kind === "m") throw new TypeError("Private method is not writable");
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-  return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
-};
-var _ZodEnum_cache;
-var _ZodNativeEnum_cache;
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -42274,10 +42261,6 @@ function createZodEnum(values, params) {
   });
 }
 var ZodEnum = class _ZodEnum extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     if (typeof input.data !== "string") {
       const ctx = this._getOrReturnCtx(input);
@@ -42289,10 +42272,10 @@ var ZodEnum = class _ZodEnum extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet(this, _ZodEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodEnum_cache, new Set(this._def.values), "f");
+    if (!this._cache) {
+      this._cache = new Set(this._def.values);
     }
-    if (!__classPrivateFieldGet(this, _ZodEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
       addIssueToContext(ctx, {
@@ -42341,13 +42324,8 @@ var ZodEnum = class _ZodEnum extends ZodType {
     });
   }
 };
-_ZodEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodEnum.create = createZodEnum;
 var ZodNativeEnum = class extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodNativeEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     const nativeEnumValues = util3.getValidEnumValues(this._def.values);
     const ctx = this._getOrReturnCtx(input);
@@ -42360,10 +42338,10 @@ var ZodNativeEnum = class extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet(this, _ZodNativeEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodNativeEnum_cache, new Set(util3.getValidEnumValues(this._def.values)), "f");
+    if (!this._cache) {
+      this._cache = new Set(util3.getValidEnumValues(this._def.values));
     }
-    if (!__classPrivateFieldGet(this, _ZodNativeEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const expectedValues = util3.objectValues(nativeEnumValues);
       addIssueToContext(ctx, {
         received: ctx.data,
@@ -42378,7 +42356,6 @@ var ZodNativeEnum = class extends ZodType {
     return this._def.values;
   }
 };
-_ZodNativeEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodNativeEnum.create = (values, params) => {
   return new ZodNativeEnum({
     values,
@@ -42519,7 +42496,7 @@ var ZodEffects = class extends ZodType {
           parent: ctx
         });
         if (!isValid(base))
-          return base;
+          return INVALID;
         const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
           throw new Error(`Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`);
@@ -42528,7 +42505,7 @@ var ZodEffects = class extends ZodType {
       } else {
         return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((base) => {
           if (!isValid(base))
-            return base;
+            return INVALID;
           return Promise.resolve(effect.transform(base.value, checkCtx)).then((result) => ({
             status: status.value,
             value: result
@@ -44308,7 +44285,7 @@ Object.freeze(types3);
 var standard_default = types3;
 
 // node_modules/mime/dist/src/Mime.js
-var __classPrivateFieldGet2 = function(receiver, state, kind, f) {
+var __classPrivateFieldGet = function(receiver, state, kind, f) {
   if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
   if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
@@ -44329,26 +44306,26 @@ var Mime = class {
     for (let [type3, extensions] of Object.entries(typeMap)) {
       type3 = type3.toLowerCase();
       extensions = extensions.map((ext) => ext.toLowerCase());
-      if (!__classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").has(type3)) {
-        __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").set(type3, /* @__PURE__ */ new Set());
+      if (!__classPrivateFieldGet(this, _Mime_typeToExtensions, "f").has(type3)) {
+        __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").set(type3, /* @__PURE__ */ new Set());
       }
-      const allExtensions = __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").get(type3);
+      const allExtensions = __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").get(type3);
       let first = true;
       for (let extension of extensions) {
         const starred = extension.startsWith("*");
         extension = starred ? extension.slice(1) : extension;
         allExtensions?.add(extension);
         if (first) {
-          __classPrivateFieldGet2(this, _Mime_typeToExtension, "f").set(type3, extension);
+          __classPrivateFieldGet(this, _Mime_typeToExtension, "f").set(type3, extension);
         }
         first = false;
         if (starred)
           continue;
-        const currentType = __classPrivateFieldGet2(this, _Mime_extensionToType, "f").get(extension);
+        const currentType = __classPrivateFieldGet(this, _Mime_extensionToType, "f").get(extension);
         if (currentType && currentType != type3 && !force) {
           throw new Error(`"${type3} -> ${extension}" conflicts with "${currentType} -> ${extension}". Pass \`force=true\` to override this definition.`);
         }
-        __classPrivateFieldGet2(this, _Mime_extensionToType, "f").set(extension, type3);
+        __classPrivateFieldGet(this, _Mime_extensionToType, "f").set(extension, type3);
       }
     }
     return this;
@@ -44362,33 +44339,33 @@ var Mime = class {
     const hasDot = ext.length < last.length - 1;
     if (!hasDot && hasPath)
       return null;
-    return __classPrivateFieldGet2(this, _Mime_extensionToType, "f").get(ext) ?? null;
+    return __classPrivateFieldGet(this, _Mime_extensionToType, "f").get(ext) ?? null;
   }
   getExtension(type3) {
     if (typeof type3 !== "string")
       return null;
     type3 = type3?.split?.(";")[0];
-    return (type3 && __classPrivateFieldGet2(this, _Mime_typeToExtension, "f").get(type3.trim().toLowerCase())) ?? null;
+    return (type3 && __classPrivateFieldGet(this, _Mime_typeToExtension, "f").get(type3.trim().toLowerCase())) ?? null;
   }
   getAllExtensions(type3) {
     if (typeof type3 !== "string")
       return null;
-    return __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").get(type3.toLowerCase()) ?? null;
+    return __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").get(type3.toLowerCase()) ?? null;
   }
   _freeze() {
     this.define = () => {
       throw new Error("define() not allowed for built-in Mime objects. See https://github.com/broofa/mime/blob/main/README.md#custom-mime-instances");
     };
     Object.freeze(this);
-    for (const extensions of __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").values()) {
+    for (const extensions of __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").values()) {
       Object.freeze(extensions);
     }
     return this;
   }
   _getTestState() {
     return {
-      types: __classPrivateFieldGet2(this, _Mime_extensionToType, "f"),
-      extensions: __classPrivateFieldGet2(this, _Mime_typeToExtension, "f")
+      types: __classPrivateFieldGet(this, _Mime_extensionToType, "f"),
+      extensions: __classPrivateFieldGet(this, _Mime_typeToExtension, "f")
     };
   }
 };
@@ -51763,8 +51740,8 @@ var getJiraClient = () => {
     host: "https://exivity.atlassian.net",
     authentication: {
       basic: {
-        username,
-        password
+        email: username,
+        apiToken: password
       }
     },
     newErrorHandling: true

--- a/release/dist/index.js
+++ b/release/dist/index.js
@@ -40185,19 +40185,6 @@ var errorUtil;
 })(errorUtil || (errorUtil = {}));
 
 // node_modules/zod/dist/esm/v3/types.js
-var __classPrivateFieldGet = function(receiver, state, kind, f) {
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-  return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
-var __classPrivateFieldSet = function(receiver, state, value, kind, f) {
-  if (kind === "m") throw new TypeError("Private method is not writable");
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-  return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
-};
-var _ZodEnum_cache;
-var _ZodNativeEnum_cache;
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -43022,10 +43009,6 @@ function createZodEnum(values, params) {
   });
 }
 var ZodEnum = class _ZodEnum extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     if (typeof input.data !== "string") {
       const ctx = this._getOrReturnCtx(input);
@@ -43037,10 +43020,10 @@ var ZodEnum = class _ZodEnum extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet(this, _ZodEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodEnum_cache, new Set(this._def.values), "f");
+    if (!this._cache) {
+      this._cache = new Set(this._def.values);
     }
-    if (!__classPrivateFieldGet(this, _ZodEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
       addIssueToContext(ctx, {
@@ -43089,13 +43072,8 @@ var ZodEnum = class _ZodEnum extends ZodType {
     });
   }
 };
-_ZodEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodEnum.create = createZodEnum;
 var ZodNativeEnum = class extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodNativeEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     const nativeEnumValues = util3.getValidEnumValues(this._def.values);
     const ctx = this._getOrReturnCtx(input);
@@ -43108,10 +43086,10 @@ var ZodNativeEnum = class extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet(this, _ZodNativeEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodNativeEnum_cache, new Set(util3.getValidEnumValues(this._def.values)), "f");
+    if (!this._cache) {
+      this._cache = new Set(util3.getValidEnumValues(this._def.values));
     }
-    if (!__classPrivateFieldGet(this, _ZodNativeEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const expectedValues = util3.objectValues(nativeEnumValues);
       addIssueToContext(ctx, {
         received: ctx.data,
@@ -43126,7 +43104,6 @@ var ZodNativeEnum = class extends ZodType {
     return this._def.values;
   }
 };
-_ZodNativeEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodNativeEnum.create = (values, params) => {
   return new ZodNativeEnum({
     values,
@@ -43267,7 +43244,7 @@ var ZodEffects = class extends ZodType {
           parent: ctx
         });
         if (!isValid(base))
-          return base;
+          return INVALID;
         const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
           throw new Error(`Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`);
@@ -43276,7 +43253,7 @@ var ZodEffects = class extends ZodType {
       } else {
         return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((base) => {
           if (!isValid(base))
-            return base;
+            return INVALID;
           return Promise.resolve(effect.transform(base.value, checkCtx)).then((result) => ({
             status: status.value,
             value: result
@@ -45056,7 +45033,7 @@ Object.freeze(types2);
 var standard_default = types2;
 
 // node_modules/mime/dist/src/Mime.js
-var __classPrivateFieldGet2 = function(receiver, state, kind, f) {
+var __classPrivateFieldGet = function(receiver, state, kind, f) {
   if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
   if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
@@ -45077,26 +45054,26 @@ var Mime = class {
     for (let [type3, extensions] of Object.entries(typeMap)) {
       type3 = type3.toLowerCase();
       extensions = extensions.map((ext) => ext.toLowerCase());
-      if (!__classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").has(type3)) {
-        __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").set(type3, /* @__PURE__ */ new Set());
+      if (!__classPrivateFieldGet(this, _Mime_typeToExtensions, "f").has(type3)) {
+        __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").set(type3, /* @__PURE__ */ new Set());
       }
-      const allExtensions = __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").get(type3);
+      const allExtensions = __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").get(type3);
       let first = true;
       for (let extension of extensions) {
         const starred = extension.startsWith("*");
         extension = starred ? extension.slice(1) : extension;
         allExtensions?.add(extension);
         if (first) {
-          __classPrivateFieldGet2(this, _Mime_typeToExtension, "f").set(type3, extension);
+          __classPrivateFieldGet(this, _Mime_typeToExtension, "f").set(type3, extension);
         }
         first = false;
         if (starred)
           continue;
-        const currentType = __classPrivateFieldGet2(this, _Mime_extensionToType, "f").get(extension);
+        const currentType = __classPrivateFieldGet(this, _Mime_extensionToType, "f").get(extension);
         if (currentType && currentType != type3 && !force) {
           throw new Error(`"${type3} -> ${extension}" conflicts with "${currentType} -> ${extension}". Pass \`force=true\` to override this definition.`);
         }
-        __classPrivateFieldGet2(this, _Mime_extensionToType, "f").set(extension, type3);
+        __classPrivateFieldGet(this, _Mime_extensionToType, "f").set(extension, type3);
       }
     }
     return this;
@@ -45110,33 +45087,33 @@ var Mime = class {
     const hasDot = ext.length < last.length - 1;
     if (!hasDot && hasPath)
       return null;
-    return __classPrivateFieldGet2(this, _Mime_extensionToType, "f").get(ext) ?? null;
+    return __classPrivateFieldGet(this, _Mime_extensionToType, "f").get(ext) ?? null;
   }
   getExtension(type3) {
     if (typeof type3 !== "string")
       return null;
     type3 = type3?.split?.(";")[0];
-    return (type3 && __classPrivateFieldGet2(this, _Mime_typeToExtension, "f").get(type3.trim().toLowerCase())) ?? null;
+    return (type3 && __classPrivateFieldGet(this, _Mime_typeToExtension, "f").get(type3.trim().toLowerCase())) ?? null;
   }
   getAllExtensions(type3) {
     if (typeof type3 !== "string")
       return null;
-    return __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").get(type3.toLowerCase()) ?? null;
+    return __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").get(type3.toLowerCase()) ?? null;
   }
   _freeze() {
     this.define = () => {
       throw new Error("define() not allowed for built-in Mime objects. See https://github.com/broofa/mime/blob/main/README.md#custom-mime-instances");
     };
     Object.freeze(this);
-    for (const extensions of __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").values()) {
+    for (const extensions of __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").values()) {
       Object.freeze(extensions);
     }
     return this;
   }
   _getTestState() {
     return {
-      types: __classPrivateFieldGet2(this, _Mime_extensionToType, "f"),
-      extensions: __classPrivateFieldGet2(this, _Mime_typeToExtension, "f")
+      types: __classPrivateFieldGet(this, _Mime_extensionToType, "f"),
+      extensions: __classPrivateFieldGet(this, _Mime_typeToExtension, "f")
     };
   }
 };
@@ -52786,8 +52763,8 @@ var getJiraClient = () => {
     host: "https://exivity.atlassian.net",
     authentication: {
       basic: {
-        username,
-        password
+        email: username,
+        apiToken: password
       }
     },
     newErrorHandling: true

--- a/release/src/common/inputs.ts
+++ b/release/src/common/inputs.ts
@@ -84,8 +84,8 @@ export const getJiraClient = () => {
     host: 'https://exivity.atlassian.net',
     authentication: {
       basic: {
-        username,
-        password,
+        email: username,
+        apiToken: password,
       },
     },
     newErrorHandling: true,

--- a/sentinel/dist/index.js
+++ b/sentinel/dist/index.js
@@ -31836,19 +31836,6 @@ var errorUtil;
 })(errorUtil || (errorUtil = {}));
 
 // node_modules/zod/dist/esm/v3/types.js
-var __classPrivateFieldGet = function(receiver, state, kind, f) {
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-  return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
-var __classPrivateFieldSet = function(receiver, state, value, kind, f) {
-  if (kind === "m") throw new TypeError("Private method is not writable");
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-  return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
-};
-var _ZodEnum_cache;
-var _ZodNativeEnum_cache;
 var ParseInputLazyPath = class {
   constructor(parent, value, path2, key) {
     this._cachedPath = [];
@@ -34673,10 +34660,6 @@ function createZodEnum(values, params) {
   });
 }
 var ZodEnum = class _ZodEnum extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     if (typeof input.data !== "string") {
       const ctx = this._getOrReturnCtx(input);
@@ -34688,10 +34671,10 @@ var ZodEnum = class _ZodEnum extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet(this, _ZodEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodEnum_cache, new Set(this._def.values), "f");
+    if (!this._cache) {
+      this._cache = new Set(this._def.values);
     }
-    if (!__classPrivateFieldGet(this, _ZodEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
       addIssueToContext(ctx, {
@@ -34740,13 +34723,8 @@ var ZodEnum = class _ZodEnum extends ZodType {
     });
   }
 };
-_ZodEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodEnum.create = createZodEnum;
 var ZodNativeEnum = class extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodNativeEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     const nativeEnumValues = util.getValidEnumValues(this._def.values);
     const ctx = this._getOrReturnCtx(input);
@@ -34759,10 +34737,10 @@ var ZodNativeEnum = class extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet(this, _ZodNativeEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodNativeEnum_cache, new Set(util.getValidEnumValues(this._def.values)), "f");
+    if (!this._cache) {
+      this._cache = new Set(util.getValidEnumValues(this._def.values));
     }
-    if (!__classPrivateFieldGet(this, _ZodNativeEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const expectedValues = util.objectValues(nativeEnumValues);
       addIssueToContext(ctx, {
         received: ctx.data,
@@ -34777,7 +34755,6 @@ var ZodNativeEnum = class extends ZodType {
     return this._def.values;
   }
 };
-_ZodNativeEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodNativeEnum.create = (values, params) => {
   return new ZodNativeEnum({
     values,
@@ -34918,7 +34895,7 @@ var ZodEffects = class extends ZodType {
           parent: ctx
         });
         if (!isValid(base))
-          return base;
+          return INVALID;
         const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
           throw new Error(`Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`);
@@ -34927,7 +34904,7 @@ var ZodEffects = class extends ZodType {
       } else {
         return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((base) => {
           if (!isValid(base))
-            return base;
+            return INVALID;
           return Promise.resolve(effect.transform(base.value, checkCtx)).then((result) => ({
             status: status.value,
             value: result
@@ -36415,7 +36392,7 @@ Object.freeze(types2);
 var standard_default = types2;
 
 // node_modules/mime/dist/src/Mime.js
-var __classPrivateFieldGet2 = function(receiver, state, kind, f) {
+var __classPrivateFieldGet = function(receiver, state, kind, f) {
   if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
   if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
@@ -36436,26 +36413,26 @@ var Mime = class {
     for (let [type, extensions] of Object.entries(typeMap)) {
       type = type.toLowerCase();
       extensions = extensions.map((ext) => ext.toLowerCase());
-      if (!__classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").has(type)) {
-        __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").set(type, /* @__PURE__ */ new Set());
+      if (!__classPrivateFieldGet(this, _Mime_typeToExtensions, "f").has(type)) {
+        __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").set(type, /* @__PURE__ */ new Set());
       }
-      const allExtensions = __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").get(type);
+      const allExtensions = __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").get(type);
       let first = true;
       for (let extension of extensions) {
         const starred = extension.startsWith("*");
         extension = starred ? extension.slice(1) : extension;
         allExtensions?.add(extension);
         if (first) {
-          __classPrivateFieldGet2(this, _Mime_typeToExtension, "f").set(type, extension);
+          __classPrivateFieldGet(this, _Mime_typeToExtension, "f").set(type, extension);
         }
         first = false;
         if (starred)
           continue;
-        const currentType = __classPrivateFieldGet2(this, _Mime_extensionToType, "f").get(extension);
+        const currentType = __classPrivateFieldGet(this, _Mime_extensionToType, "f").get(extension);
         if (currentType && currentType != type && !force) {
           throw new Error(`"${type} -> ${extension}" conflicts with "${currentType} -> ${extension}". Pass \`force=true\` to override this definition.`);
         }
-        __classPrivateFieldGet2(this, _Mime_extensionToType, "f").set(extension, type);
+        __classPrivateFieldGet(this, _Mime_extensionToType, "f").set(extension, type);
       }
     }
     return this;
@@ -36469,33 +36446,33 @@ var Mime = class {
     const hasDot = ext.length < last.length - 1;
     if (!hasDot && hasPath)
       return null;
-    return __classPrivateFieldGet2(this, _Mime_extensionToType, "f").get(ext) ?? null;
+    return __classPrivateFieldGet(this, _Mime_extensionToType, "f").get(ext) ?? null;
   }
   getExtension(type) {
     if (typeof type !== "string")
       return null;
     type = type?.split?.(";")[0];
-    return (type && __classPrivateFieldGet2(this, _Mime_typeToExtension, "f").get(type.trim().toLowerCase())) ?? null;
+    return (type && __classPrivateFieldGet(this, _Mime_typeToExtension, "f").get(type.trim().toLowerCase())) ?? null;
   }
   getAllExtensions(type) {
     if (typeof type !== "string")
       return null;
-    return __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").get(type.toLowerCase()) ?? null;
+    return __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").get(type.toLowerCase()) ?? null;
   }
   _freeze() {
     this.define = () => {
       throw new Error("define() not allowed for built-in Mime objects. See https://github.com/broofa/mime/blob/main/README.md#custom-mime-instances");
     };
     Object.freeze(this);
-    for (const extensions of __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").values()) {
+    for (const extensions of __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").values()) {
       Object.freeze(extensions);
     }
     return this;
   }
   _getTestState() {
     return {
-      types: __classPrivateFieldGet2(this, _Mime_extensionToType, "f"),
-      extensions: __classPrivateFieldGet2(this, _Mime_typeToExtension, "f")
+      types: __classPrivateFieldGet(this, _Mime_extensionToType, "f"),
+      extensions: __classPrivateFieldGet(this, _Mime_typeToExtension, "f")
     };
   }
 };

--- a/trigger-workflow/dist/index.js
+++ b/trigger-workflow/dist/index.js
@@ -23940,19 +23940,6 @@ var errorUtil;
 })(errorUtil || (errorUtil = {}));
 
 // node_modules/zod/dist/esm/v3/types.js
-var __classPrivateFieldGet = function(receiver, state, kind, f) {
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-  return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
-var __classPrivateFieldSet = function(receiver, state, value, kind, f) {
-  if (kind === "m") throw new TypeError("Private method is not writable");
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-  return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
-};
-var _ZodEnum_cache;
-var _ZodNativeEnum_cache;
 var ParseInputLazyPath = class {
   constructor(parent, value, path, key) {
     this._cachedPath = [];
@@ -26777,10 +26764,6 @@ function createZodEnum(values, params) {
   });
 }
 var ZodEnum = class _ZodEnum extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     if (typeof input.data !== "string") {
       const ctx = this._getOrReturnCtx(input);
@@ -26792,10 +26775,10 @@ var ZodEnum = class _ZodEnum extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet(this, _ZodEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodEnum_cache, new Set(this._def.values), "f");
+    if (!this._cache) {
+      this._cache = new Set(this._def.values);
     }
-    if (!__classPrivateFieldGet(this, _ZodEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
       addIssueToContext(ctx, {
@@ -26844,13 +26827,8 @@ var ZodEnum = class _ZodEnum extends ZodType {
     });
   }
 };
-_ZodEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodEnum.create = createZodEnum;
 var ZodNativeEnum = class extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodNativeEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     const nativeEnumValues = util.getValidEnumValues(this._def.values);
     const ctx = this._getOrReturnCtx(input);
@@ -26863,10 +26841,10 @@ var ZodNativeEnum = class extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet(this, _ZodNativeEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodNativeEnum_cache, new Set(util.getValidEnumValues(this._def.values)), "f");
+    if (!this._cache) {
+      this._cache = new Set(util.getValidEnumValues(this._def.values));
     }
-    if (!__classPrivateFieldGet(this, _ZodNativeEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const expectedValues = util.objectValues(nativeEnumValues);
       addIssueToContext(ctx, {
         received: ctx.data,
@@ -26881,7 +26859,6 @@ var ZodNativeEnum = class extends ZodType {
     return this._def.values;
   }
 };
-_ZodNativeEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodNativeEnum.create = (values, params) => {
   return new ZodNativeEnum({
     values,
@@ -27022,7 +26999,7 @@ var ZodEffects = class extends ZodType {
           parent: ctx
         });
         if (!isValid(base))
-          return base;
+          return INVALID;
         const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
           throw new Error(`Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`);
@@ -27031,7 +27008,7 @@ var ZodEffects = class extends ZodType {
       } else {
         return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((base) => {
           if (!isValid(base))
-            return base;
+            return INVALID;
           return Promise.resolve(effect.transform(base.value, checkCtx)).then((result) => ({
             status: status.value,
             value: result
@@ -28519,7 +28496,7 @@ Object.freeze(types2);
 var standard_default = types2;
 
 // node_modules/mime/dist/src/Mime.js
-var __classPrivateFieldGet2 = function(receiver, state, kind, f) {
+var __classPrivateFieldGet = function(receiver, state, kind, f) {
   if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
   if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
   return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
@@ -28540,26 +28517,26 @@ var Mime = class {
     for (let [type, extensions] of Object.entries(typeMap)) {
       type = type.toLowerCase();
       extensions = extensions.map((ext) => ext.toLowerCase());
-      if (!__classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").has(type)) {
-        __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").set(type, /* @__PURE__ */ new Set());
+      if (!__classPrivateFieldGet(this, _Mime_typeToExtensions, "f").has(type)) {
+        __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").set(type, /* @__PURE__ */ new Set());
       }
-      const allExtensions = __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").get(type);
+      const allExtensions = __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").get(type);
       let first = true;
       for (let extension of extensions) {
         const starred = extension.startsWith("*");
         extension = starred ? extension.slice(1) : extension;
         allExtensions?.add(extension);
         if (first) {
-          __classPrivateFieldGet2(this, _Mime_typeToExtension, "f").set(type, extension);
+          __classPrivateFieldGet(this, _Mime_typeToExtension, "f").set(type, extension);
         }
         first = false;
         if (starred)
           continue;
-        const currentType = __classPrivateFieldGet2(this, _Mime_extensionToType, "f").get(extension);
+        const currentType = __classPrivateFieldGet(this, _Mime_extensionToType, "f").get(extension);
         if (currentType && currentType != type && !force) {
           throw new Error(`"${type} -> ${extension}" conflicts with "${currentType} -> ${extension}". Pass \`force=true\` to override this definition.`);
         }
-        __classPrivateFieldGet2(this, _Mime_extensionToType, "f").set(extension, type);
+        __classPrivateFieldGet(this, _Mime_extensionToType, "f").set(extension, type);
       }
     }
     return this;
@@ -28573,33 +28550,33 @@ var Mime = class {
     const hasDot = ext.length < last.length - 1;
     if (!hasDot && hasPath)
       return null;
-    return __classPrivateFieldGet2(this, _Mime_extensionToType, "f").get(ext) ?? null;
+    return __classPrivateFieldGet(this, _Mime_extensionToType, "f").get(ext) ?? null;
   }
   getExtension(type) {
     if (typeof type !== "string")
       return null;
     type = type?.split?.(";")[0];
-    return (type && __classPrivateFieldGet2(this, _Mime_typeToExtension, "f").get(type.trim().toLowerCase())) ?? null;
+    return (type && __classPrivateFieldGet(this, _Mime_typeToExtension, "f").get(type.trim().toLowerCase())) ?? null;
   }
   getAllExtensions(type) {
     if (typeof type !== "string")
       return null;
-    return __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").get(type.toLowerCase()) ?? null;
+    return __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").get(type.toLowerCase()) ?? null;
   }
   _freeze() {
     this.define = () => {
       throw new Error("define() not allowed for built-in Mime objects. See https://github.com/broofa/mime/blob/main/README.md#custom-mime-instances");
     };
     Object.freeze(this);
-    for (const extensions of __classPrivateFieldGet2(this, _Mime_typeToExtensions, "f").values()) {
+    for (const extensions of __classPrivateFieldGet(this, _Mime_typeToExtensions, "f").values()) {
       Object.freeze(extensions);
     }
     return this;
   }
   _getTestState() {
     return {
-      types: __classPrivateFieldGet2(this, _Mime_extensionToType, "f"),
-      extensions: __classPrivateFieldGet2(this, _Mime_typeToExtension, "f")
+      types: __classPrivateFieldGet(this, _Mime_extensionToType, "f"),
+      extensions: __classPrivateFieldGet(this, _Mime_typeToExtension, "f")
     };
   }
 };

--- a/virustotal/dist/index.js
+++ b/virustotal/dist/index.js
@@ -42263,19 +42263,6 @@ var errorUtil;
 })(errorUtil || (errorUtil = {}));
 
 // node_modules/zod/dist/esm/v3/types.js
-var __classPrivateFieldGet2 = function(receiver, state, kind, f) {
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
-  return kind === "m" ? f : kind === "a" ? f.call(receiver) : f ? f.value : state.get(receiver);
-};
-var __classPrivateFieldSet = function(receiver, state, value, kind, f) {
-  if (kind === "m") throw new TypeError("Private method is not writable");
-  if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
-  if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot write private member to an object whose class did not declare it");
-  return kind === "a" ? f.call(receiver, value) : f ? f.value = value : state.set(receiver, value), value;
-};
-var _ZodEnum_cache;
-var _ZodNativeEnum_cache;
 var ParseInputLazyPath = class {
   constructor(parent, value, path2, key) {
     this._cachedPath = [];
@@ -45100,10 +45087,6 @@ function createZodEnum(values, params) {
   });
 }
 var ZodEnum = class _ZodEnum extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     if (typeof input.data !== "string") {
       const ctx = this._getOrReturnCtx(input);
@@ -45115,10 +45098,10 @@ var ZodEnum = class _ZodEnum extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet2(this, _ZodEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodEnum_cache, new Set(this._def.values), "f");
+    if (!this._cache) {
+      this._cache = new Set(this._def.values);
     }
-    if (!__classPrivateFieldGet2(this, _ZodEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const ctx = this._getOrReturnCtx(input);
       const expectedValues = this._def.values;
       addIssueToContext(ctx, {
@@ -45167,13 +45150,8 @@ var ZodEnum = class _ZodEnum extends ZodType {
     });
   }
 };
-_ZodEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodEnum.create = createZodEnum;
 var ZodNativeEnum = class extends ZodType {
-  constructor() {
-    super(...arguments);
-    _ZodNativeEnum_cache.set(this, void 0);
-  }
   _parse(input) {
     const nativeEnumValues = util.getValidEnumValues(this._def.values);
     const ctx = this._getOrReturnCtx(input);
@@ -45186,10 +45164,10 @@ var ZodNativeEnum = class extends ZodType {
       });
       return INVALID;
     }
-    if (!__classPrivateFieldGet2(this, _ZodNativeEnum_cache, "f")) {
-      __classPrivateFieldSet(this, _ZodNativeEnum_cache, new Set(util.getValidEnumValues(this._def.values)), "f");
+    if (!this._cache) {
+      this._cache = new Set(util.getValidEnumValues(this._def.values));
     }
-    if (!__classPrivateFieldGet2(this, _ZodNativeEnum_cache, "f").has(input.data)) {
+    if (!this._cache.has(input.data)) {
       const expectedValues = util.objectValues(nativeEnumValues);
       addIssueToContext(ctx, {
         received: ctx.data,
@@ -45204,7 +45182,6 @@ var ZodNativeEnum = class extends ZodType {
     return this._def.values;
   }
 };
-_ZodNativeEnum_cache = /* @__PURE__ */ new WeakMap();
 ZodNativeEnum.create = (values, params) => {
   return new ZodNativeEnum({
     values,
@@ -45345,7 +45322,7 @@ var ZodEffects = class extends ZodType {
           parent: ctx
         });
         if (!isValid(base))
-          return base;
+          return INVALID;
         const result = effect.transform(base.value, checkCtx);
         if (result instanceof Promise) {
           throw new Error(`Asynchronous transform encountered during synchronous parse operation. Use .parseAsync instead.`);
@@ -45354,7 +45331,7 @@ var ZodEffects = class extends ZodType {
       } else {
         return this._def.schema._parseAsync({ data: ctx.data, path: ctx.path, parent: ctx }).then((base) => {
           if (!isValid(base))
-            return base;
+            return INVALID;
           return Promise.resolve(effect.transform(base.value, checkCtx)).then((result) => ({
             status: status.value,
             value: result


### PR DESCRIPTION
Revise the Jira client authentication method to utilize 'email' and 'apiToken' fields instead of 'username' and 'password'. This change enhances security and aligns with updated authentication standards.