### PR TITLE
chore: Add Docker login input option to build actions

### DIFF
--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -38,7 +38,7 @@ inputs:
   useSSH:
     description: Pass the SSH agent to the build context
     required: false
-    default: 'false'
+    default: "false"
   secrets:
     description: Secrets for Docker build
     required: false
@@ -47,11 +47,15 @@ inputs:
     required: false
   platforms:
     description:
-      'Platforms for multi-platform builds. Requires docker buildx to be
+      "Platforms for multi-platform builds. Requires docker buildx to be
       installed and configured, see
-      https://github.com/exivity/setup-buildx-action'
+      https://github.com/exivity/setup-buildx-action"
     required: false
-    default: 'linux/amd64'
+    default: "linux/amd64"
+  login:
+    description: Whether to perform docker login. Defaults to true.
+    required: false
+    default: "true"
 runs:
   using: node20
   main: dist/index.js

--- a/build-image/src/index.ts
+++ b/build-image/src/index.ts
@@ -19,6 +19,7 @@ async function run() {
   const secrets = getInput('secrets')
   const buildArgs = getInput('buildArgs')
   const platforms = getInput('platforms')
+  const login = getBooleanInput('login')
 
   // Get all relevant metadata for the image
   const labels = getLabels(name)
@@ -30,11 +31,13 @@ async function run() {
   table('Labels', JSON.stringify(labels, undefined, 2))
 
   await writeMetadataFile(name)
-  await dockerLogin({
-    registry,
-    user,
-    password,
-  })
+  if (login) {
+    await dockerLogin({
+      registry,
+      user,
+      password,
+    })
+  }
 
   await dockerBuild({
     dockerfile,

--- a/build-push-image/action.yml
+++ b/build-push-image/action.yml
@@ -33,7 +33,7 @@ inputs:
   useSSH:
     description: Pass the SSH agent to the build context
     required: false
-    default: 'false'
+    default: "false"
   secrets:
     description: Secrets for Docker build
     required: false
@@ -42,15 +42,19 @@ inputs:
     required: false
   platforms:
     description:
-      'Platforms for multi-platform builds (e.g. linux/amd64,linux/arm64).
+      "Platforms for multi-platform builds (e.g. linux/amd64,linux/arm64).
       Requires docker buildx to be installed and configured. See
-      https://github.com/exivity/setup-buildx-action'
+      https://github.com/exivity/setup-buildx-action"
     required: false
-    default: 'linux/amd64'
+    default: "linux/amd64"
   only-build:
     description: Skip pushing the image, so only build
     required: false
-    default: 'false'
+    default: "false"
+  login:
+    description: Whether to perform docker login. Defaults to true.
+    required: false
+    default: "true"
 runs:
   using: node20
   main: dist/index.js

--- a/build-push-image/src/index.ts
+++ b/build-push-image/src/index.ts
@@ -24,6 +24,7 @@ async function run() {
   const target = getInput('target')
   const platforms = getInput('platforms')
   const onlyBuild = getBooleanInput('only-build') // New option to skip push
+  const login = getBooleanInput('login')
 
   // Get all relevant metadata for the image
   const labels = getLabels(name)
@@ -37,11 +38,13 @@ async function run() {
   await writeMetadataFile(name)
 
   // Perform login only if we're also going to push
-  await dockerLogin({
-    registry,
-    user,
-    password,
-  })
+  if (login) {
+    await dockerLogin({
+      registry,
+      user,
+      password,
+    })
+  }
 
   await dockerBuild({
     dockerfile,


### PR DESCRIPTION
Introduce a new input option for Docker login in the build-image and build-push-image actions, allowing users to specify whether to perform a login. Default behavior remains unchanged.