### PR TITLE
chore: disable auto generate labels for images

### DIFF
--- a/lib/image.ts
+++ b/lib/image.ts
@@ -36,11 +36,13 @@ function capitalizeFirstLetter(string: string) {
 export function getLabels(name: string) {
   const { owner, fqn } = getRepository()
 
+  // Generate default labels that can be overridden by Dockerfile
   return {
     'org.opencontainers.image.vendor': capitalizeFirstLetter(owner),
     'org.opencontainers.image.title': name,
-    'org.opencontainers.image.description': name,
-    'org.opencontainers.image.source': `https://github.com/${fqn}`,
+    // Don't override description and source - let Dockerfile take precedence
+    // 'org.opencontainers.image.description': name,
+    // 'org.opencontainers.image.source': `https://github.com/${fqn}`,
     'org.opencontainers.image.created': new Date().toISOString(),
     'org.opencontainers.image.revision': getSha(),
     ...(owner === 'exivity'


### PR DESCRIPTION
In this pr removed automatic generation of source and description labels, allow Dockerfiles to set these labels without being overridden.
This change could fixes the Dependabot detection issue by ensuring the Dockerfile's OpenContainer metadata takes precedence over auto-generated labels.

See: https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories#docker