### PR TITLE
docs: update native GitHub Action examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ release tag in the release repository, plus new tags in all released components.
 `release` mode by using the checkout actions like this:
 
 ```yaml
-- uses: actions/checkout@v3
+- uses: actions/checkout@v6
   with:
     fetch-depth: 0
 ```

--- a/push-to-central-repo/README.md
+++ b/push-to-central-repo/README.md
@@ -185,7 +185,7 @@ jobs:
   push-assets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: exivity/actions/push-to-central-repo@main
         with:
           central-repo-owner: 'your-org'
@@ -209,7 +209,7 @@ jobs:
   sync-assets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: exivity/actions/push-to-central-repo@main
         with:
           central-repo-owner: 'your-org'

--- a/push-to-central-repo/examples.md
+++ b/push-to-central-repo/examples.md
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Push to central repository
         uses: exivity/actions/push-to-central-repo@main
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Test push (dry run)
         uses: exivity/actions/push-to-central-repo@main
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync to central repository
         uses: exivity/actions/push-to-central-repo@main


### PR DESCRIPTION
## Summary
- update stale official GitHub Action examples to the current `actions/checkout@v6` tag
- align the main action README and push-to-central-repo docs/examples with the versions already used in active workflow files

## Notes
- I verified the active workflow files in this repo are already on current major versions for the official GitHub actions they use
- this PR only updates the outdated documentation/example references

## Verification
- checked latest tags from the upstream GitHub action repos via GitHub API
- `git diff --check`