### PR TITLE
fix: preserve virustotal status context

### DIFF
--- a/virustotal/dist/index.js
+++ b/virustotal/dist/index.js
@@ -52628,7 +52628,7 @@ async function getPendingVirusTotalStatuses(octokit) {
   }
   return statuses;
 }
-async function writeStatus2(octokit, result, sha) {
+async function writeStatus2(octokit, result, sha, context3) {
   const { owner, repo } = getRepository();
   return writeStatus({
     octokit,
@@ -52636,7 +52636,7 @@ async function writeStatus2(octokit, result, sha) {
     repo,
     sha: sha ?? getSha(),
     state: result.status === "pending" ? "pending" : result.flagged === 0 ? "success" : "failure",
-    context: `virustotal (${result.filename})`,
+    context: context3 ?? `virustotal (${result.filename})`,
     description: result.status === "completed" ? result.flagged ? `Detected as malicious or suspicious by ${result.flagged} security vendors` : "No security vendors flagged this file as malicious" : void 0,
     target_url: filehashToGuiUrl(result.filehash)
   });
@@ -52687,7 +52687,12 @@ async function run() {
     case ModeCheck:
       for (const pendingStatus of await getPendingVirusTotalStatuses(octokit)) {
         const result = await check2(vt2, pendingStatus);
-        await writeStatus2(octokit, result, pendingStatus.sha);
+        await writeStatus2(
+          octokit,
+          result,
+          pendingStatus.sha,
+          pendingStatus.context
+        );
       }
       break;
     default:

--- a/virustotal/src/index.ts
+++ b/virustotal/src/index.ts
@@ -71,7 +71,12 @@ async function run() {
       // Run
       for (const pendingStatus of await getPendingVirusTotalStatuses(octokit)) {
         const result = await check(vt, pendingStatus)
-        await writeStatus(octokit, result, pendingStatus.sha)
+        await writeStatus(
+          octokit,
+          result,
+          pendingStatus.sha,
+          pendingStatus.context,
+        )
       }
       break
     default:

--- a/virustotal/src/status.ts
+++ b/virustotal/src/status.ts
@@ -76,6 +76,7 @@ export async function writeStatus(
   octokit: ReturnType<typeof getOctokit>,
   result: AnalysisResult,
   sha?: string,
+  context?: string,
 ) {
   const { owner, repo } = getRepository()
   return writeStatusGitHub({
@@ -89,7 +90,7 @@ export async function writeStatus(
         : result.flagged === 0
           ? 'success'
           : 'failure',
-    context: `virustotal (${result.filename})`,
+    context: context ?? `virustotal (${result.filename})`,
     description:
       result.status === 'completed'
         ? result.flagged


### PR DESCRIPTION
## Summary
- preserve the original pending commit-status context when the virustotal action runs in `check` mode
- keep `analyse` mode behavior unchanged, so newly created statuses still use the scanned filename
- rebuild the bundled `virustotal/dist/index.js`

## Why
When VirusTotal returns a temporary filename like `dgq9sp0u9.exe`, the current check flow writes a new status context such as `virustotal (dgq9sp0u9.exe)` instead of completing the existing pending context like `virustotal (edify)`. That leaves the original check stuck in pending.

## Validation
- `yarn install --immutable`
- `yarn build:virustotal`
- `git diff --check`