### PR TITLE
fix: bridge release commits across subtree cutover

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -399,6 +399,34 @@ export async function getCommitsSince({
   return commits
 }
 
+export async function getComparedCommits({
+  octokit,
+  owner,
+  repo,
+  base,
+  head,
+}: {
+  octokit: ReturnType<typeof getOctokit>
+  owner: string
+  repo: string
+  base: string
+  head: string
+}) {
+  const { data } = await octokit.rest.repos.compareCommitsWithBasehead({
+    owner,
+    repo,
+    basehead: `${base}...${head}`,
+  })
+
+  if (data.total_commits > data.commits.length) {
+    warning(
+      `Compare truncated for ${owner}/${repo} between ${base} and ${head}: ${data.commits.length}/${data.total_commits} commits returned`,
+    )
+  }
+
+  return data.commits
+}
+
 export async function review({
   octokit,
   owner,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build:virustotal": "yarn esbuild:generic virustotal/src/index.ts --outfile=virustotal/dist/index.js",
     "esbuild:generic": "esbuild --bundle --platform=node --target=node24",
     "format": "prettier --write .",
-    "test:release-source-mapping": "node --test release/src/common/releaseRepositories.test.js",
+    "test:release-source-mapping": "node --test release/src/common/releaseRepositories.test.js release/src/jira/cutoverBridge.test.js",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"
   },

--- a/release/dist/index.js
+++ b/release/dist/index.js
@@ -30215,6 +30215,60 @@ var require_releaseRepositories = __commonJS({
   }
 });
 
+// release/src/jira/cutoverBridge.js
+var require_cutoverBridge = __commonJS({
+  "release/src/jira/cutoverBridge.js"(exports2, module2) {
+    "use strict";
+    function parseSubtreeSplitSha(message, sourcePath) {
+      if (!sourcePath) {
+        return null;
+      }
+      const subtreeDirMatch = message.match(/^git-subtree-dir:\s*(.+)$/m);
+      if (!subtreeDirMatch || subtreeDirMatch[1].trim() !== sourcePath) {
+        return null;
+      }
+      const subtreeSplitMatch = message.match(
+        /^git-subtree-split:\s*([0-9a-f]{7,40})$/im
+      );
+      return subtreeSplitMatch ? subtreeSplitMatch[1] : null;
+    }
+    function buildLegacyBridgeRanges2({
+      component,
+      sourceRepo,
+      sourcePath,
+      releasedSha,
+      sourceCommits
+    }) {
+      if (sourceRepo === component || !sourcePath) {
+        return [];
+      }
+      const seen = /* @__PURE__ */ new Set();
+      return sourceCommits.flatMap((commit) => {
+        const splitSha = parseSubtreeSplitSha(commit.commit.message, sourcePath);
+        if (!splitSha) {
+          return [];
+        }
+        const key = `${component}:${releasedSha}:${splitSha}`;
+        if (seen.has(key)) {
+          return [];
+        }
+        seen.add(key);
+        return [
+          {
+            repo: component,
+            baseSha: releasedSha,
+            headSha: splitSha
+          }
+        ];
+      });
+    }
+    module2.exports = {
+      parseSubtreeSplitSha,
+      buildLegacyBridgeRanges: buildLegacyBridgeRanges2
+    };
+  }
+});
+
 // node_modules/semver/internal/constants.js
 var require_constants6 = __commonJS({
   "node_modules/semver/internal/constants.js"(exports2, module2) {
@@ -62869,6 +62923,25 @@ async function getCommitsSince({
   );
   return commits;
 }
+async function getComparedCommits({
+  octokit,
+  owner,
+  repo,
+  base,
+  head
+}) {
+  const { data } = await octokit.rest.repos.compareCommitsWithBasehead({
+    owner,
+    repo,
+    basehead: `${base}...${head}`
+  });
+  if (data.total_commits > data.commits.length) {
+    warning(
+      `Compare truncated for ${owner}/${repo} between ${base} and ${head}: ${data.commits.length}/${data.total_commits} commits returned`
+    );
+  }
+  return data.commits;
+}
 async function dispatchWorkflow({
   octokit,
   owner,
@@ -62988,9 +63061,7 @@ async function exec2(command, args) {
 }
 
 // release/src/common/inputs.ts
-var {
-  resolveReleaseRepositories
-} = require_releaseRepositories();
+var { resolveReleaseRepositories } = require_releaseRepositories();
 async function readTextFile(path4) {
   try {
     return (0, import_promises.readFile)(path4, "utf8");
@@ -64503,6 +64574,7 @@ var getMissingReleaseNotes = pipe2(
 );
 
 // release/src/jira/getRepoJiraIssues.ts
+var import_cutoverBridge = __toESM(require_cutoverBridge());
 var getFirstLine = pipe2(split_default("\n"), pathOr_default("", [0]));
 var removeFirstLine = pipe2(split_default("\n"), tail_default, join_default("\n"));
 var getRepoJiraIssues = async ({
@@ -64526,7 +64598,7 @@ var getRepoJiraIssues = async ({
       `Could not find a release timestamp for ${component} at ${releasedSha}`
     );
   }
-  const commits = await getCommitsSince({
+  const sourceCommits = await getCommitsSince({
     octokit,
     owner: "exivity",
     repo: sourceRepo,
@@ -64538,15 +64610,44 @@ var getRepoJiraIssues = async ({
       sha: releasedSha
     }
   });
+  const legacyBridgeRanges = (0, import_cutoverBridge.buildLegacyBridgeRanges)({
+    component,
+    sourceRepo,
+    sourcePath,
+    releasedSha,
+    sourceCommits
+  });
+  const legacyCommits = (await Promise.all(
+    legacyBridgeRanges.map(async ({ repo, baseSha, headSha }) => {
+      const commits2 = await getComparedCommits({
+        octokit,
+        owner: "exivity",
+        repo,
+        base: baseSha,
+        head: headSha
+      });
+      info(
+        `  Found ${commits2.length} legacy commits between ${baseSha} and ${headSha} in exivity/${repo} before subtree import into exivity/${sourceRepo}#${releaseBranch2}${sourcePath ? ` (${sourcePath})` : ""}`
+      );
+      return commits2.map((commit) => ({ repo, commit }));
+    })
+  )).flat();
+  const commits = [
+    ...legacyCommits,
+    ...sourceCommits.map((commit) => ({
+      repo: sourceRepo,
+      commit
+    }))
+  ];
   const jiraIssueKeys = [];
   return {
     jiraIssueKeys,
     issues: await Promise.all(
-      commits.map(async (commit) => {
+      commits.map(async ({ repo, commit }) => {
         const associatedPullRequest = await getAssociatedPullRequest({
           octokit,
           owner: "exivity",
-          repo: sourceRepo,
+          repo,
           sha: commit.sha
         });
         debug2(() => `PR.title: ${associatedPullRequest?.title}`);
@@ -64575,9 +64676,9 @@ var getRepoJiraIssues = async ({
                   type: issueType,
                   breaking,
                   noReleaseNotesNeeded: noReleaseNotesNeeded(issue3),
-                  commit: `[exivity/${sourceRepo}@${commit.sha.substring(0, 7)}](${commit.html_url})`,
+                  commit: `[exivity/${repo}@${commit.sha.substring(0, 7)}](${commit.html_url})`,
                   issue: `[${issue3.key}](https://exivity.atlassian.net/browse/${issue3.key})`,
-                  pullRequest: associatedPullRequest ? `[exivity/${sourceRepo}#${associatedPullRequest.number}](${associatedPullRequest.url})` : "No pull request",
+                  pullRequest: associatedPullRequest ? `[exivity/${repo}#${associatedPullRequest.number}](${associatedPullRequest.url})` : "No pull request",
                   milestone: epic ? `[${getEpic(issue3)}](https://exivity.atlassian.net/browse/${getEpic(issue3)})` : "No milestone"
                 }
               ];
@@ -64939,10 +65040,7 @@ async function prepare() {
   }
   logIssues(issues);
   const currentVersion = (await getLockFile()).version;
-  const upcomingVersion = inferVersionFromJiraIssues(
-    currentVersion,
-    issues
-  );
+  const upcomingVersion = inferVersionFromJiraIssues(currentVersion, issues);
   await writeIssueFile(issuesPerRepo.flatMap(jiraIssueKeysProp));
   await writeLockFile(upcomingVersion);
   await writeChangelog(upcomingVersion, issues);

--- a/release/src/jira/cutoverBridge.js
+++ b/release/src/jira/cutoverBridge.js
@@ -1,0 +1,60 @@
+function parseSubtreeSplitSha(message, sourcePath) {
+  if (!sourcePath) {
+    return null
+  }
+
+  const subtreeDirMatch = message.match(/^git-subtree-dir:\s*(.+)$/m)
+
+  if (!subtreeDirMatch || subtreeDirMatch[1].trim() !== sourcePath) {
+    return null
+  }
+
+  const subtreeSplitMatch = message.match(
+    /^git-subtree-split:\s*([0-9a-f]{7,40})$/im,
+  )
+
+  return subtreeSplitMatch ? subtreeSplitMatch[1] : null
+}
+
+function buildLegacyBridgeRanges({
+  component,
+  sourceRepo,
+  sourcePath,
+  releasedSha,
+  sourceCommits,
+}) {
+  if (sourceRepo === component || !sourcePath) {
+    return []
+  }
+
+  const seen = new Set()
+
+  return sourceCommits.flatMap((commit) => {
+    const splitSha = parseSubtreeSplitSha(commit.commit.message, sourcePath)
+
+    if (!splitSha) {
+      return []
+    }
+
+    const key = `${component}:${releasedSha}:${splitSha}`
+
+    if (seen.has(key)) {
+      return []
+    }
+
+    seen.add(key)
+
+    return [
+      {
+        repo: component,
+        baseSha: releasedSha,
+        headSha: splitSha,
+      },
+    ]
+  })
+}
+
+module.exports = {
+  parseSubtreeSplitSha,
+  buildLegacyBridgeRanges,
+}

--- a/release/src/jira/cutoverBridge.test.js
+++ b/release/src/jira/cutoverBridge.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  parseSubtreeSplitSha,
+  buildLegacyBridgeRanges,
+} = require('./cutoverBridge')
+
+test('parseSubtreeSplitSha reads subtree metadata for the managed path', () => {
+  const message = `Add edify subtree from exivity/edify
+
+git-subtree-dir: edify
+git-subtree-mainline: 0b6e7e25fa7e2d7173fe79ef10655415b3a06716
+git-subtree-split: f7fb94604203670ac7ebbd1860d50e1241b804fd`
+
+  assert.equal(
+    parseSubtreeSplitSha(message, 'edify'),
+    'f7fb94604203670ac7ebbd1860d50e1241b804fd',
+  )
+})
+
+test('parseSubtreeSplitSha ignores subtree metadata for a different path', () => {
+  const message = `Add proximity subtree from exivity/proximity
+
+git-subtree-dir: proximity
+git-subtree-mainline: abcdef0123456789
+git-subtree-split: 1234567890abcdef1234567890abcdef12345678`
+
+  assert.equal(parseSubtreeSplitSha(message, 'edify'), null)
+})
+
+test('buildLegacyBridgeRanges creates a bridge range for the first product-backed release', () => {
+  const sourceCommits = [
+    {
+      sha: '4ed7d15a5',
+      commit: {
+        message: 'chore: add workflows',
+      },
+    },
+    {
+      sha: '4b4935d9a',
+      commit: {
+        message: `Add edify subtree from exivity/edify
+
+git-subtree-dir: edify
+git-subtree-mainline: 0b6e7e25fa7e2d7173fe79ef10655415b3a06716
+git-subtree-split: f7fb94604203670ac7ebbd1860d50e1241b804fd`,
+      },
+    },
+  ]
+
+  assert.deepEqual(
+    buildLegacyBridgeRanges({
+      component: 'edify',
+      sourceRepo: 'product',
+      sourcePath: 'edify',
+      releasedSha: '484ec20a345d8e916405872b1ebee29f55a40793',
+      sourceCommits,
+    }),
+    [
+      {
+        repo: 'edify',
+        baseSha: '484ec20a345d8e916405872b1ebee29f55a40793',
+        headSha: 'f7fb94604203670ac7ebbd1860d50e1241b804fd',
+      },
+    ],
+  )
+})
+
+test('buildLegacyBridgeRanges does nothing for standalone repositories', () => {
+  assert.deepEqual(
+    buildLegacyBridgeRanges({
+      component: 'chronos',
+      sourceRepo: 'chronos',
+      sourcePath: undefined,
+      releasedSha: 'sha-chronos',
+      sourceCommits: [],
+    }),
+    [],
+  )
+})

--- a/release/src/jira/getRepoJiraIssues.ts
+++ b/release/src/jira/getRepoJiraIssues.ts
@@ -12,6 +12,7 @@ import {
 
 import {
   getCommit,
+  getComparedCommits,
   getCommitsSince,
   getAssociatedPullRequest,
 } from '../../../lib/github'
@@ -33,9 +34,15 @@ import {
   getIssueType,
 } from './utils'
 import { info } from '@actions/core'
+import { buildLegacyBridgeRanges } from './cutoverBridge'
 
 export const getFirstLine = pipe(split('\n'), pathOr('', [0]))
 export const removeFirstLine = pipe(split('\n'), tail, join('\n'))
+
+type RepoCommit = {
+  repo: string
+  commit: Awaited<ReturnType<typeof getCommitsSince>>[number]
+}
 
 export const getRepoJiraIssues = async ({
   component,
@@ -61,7 +68,7 @@ export const getRepoJiraIssues = async ({
     )
   }
 
-  const commits = await getCommitsSince({
+  const sourceCommits = await getCommitsSince({
     octokit,
     owner: 'exivity',
     repo: sourceRepo,
@@ -74,16 +81,52 @@ export const getRepoJiraIssues = async ({
     },
   })
 
+  const legacyBridgeRanges = buildLegacyBridgeRanges({
+    component,
+    sourceRepo,
+    sourcePath,
+    releasedSha,
+    sourceCommits,
+  })
+
+  const legacyCommits: RepoCommit[] = (
+    await Promise.all(
+      legacyBridgeRanges.map(async ({ repo, baseSha, headSha }) => {
+        const commits = await getComparedCommits({
+          octokit,
+          owner: 'exivity',
+          repo,
+          base: baseSha,
+          head: headSha,
+        })
+
+        info(
+          `  Found ${commits.length} legacy commits between ${baseSha} and ${headSha} in exivity/${repo} before subtree import into exivity/${sourceRepo}#${releaseBranch}${sourcePath ? ` (${sourcePath})` : ''}`,
+        )
+
+        return commits.map((commit) => ({ repo, commit }))
+      }),
+    )
+  ).flat()
+
+  const commits: RepoCommit[] = [
+    ...legacyCommits,
+    ...sourceCommits.map((commit) => ({
+      repo: sourceRepo,
+      commit,
+    })),
+  ]
+
   const jiraIssueKeys: string[] = []
 
   return {
     jiraIssueKeys,
     issues: await Promise.all(
-      commits.map(async (commit) => {
+      commits.map(async ({ repo, commit }) => {
         const associatedPullRequest = await getAssociatedPullRequest({
           octokit,
           owner: 'exivity',
-          repo: sourceRepo,
+          repo,
           sha: commit.sha,
         })
 
@@ -121,10 +164,10 @@ export const getRepoJiraIssues = async ({
                   type: issueType,
                   breaking,
                   noReleaseNotesNeeded: noReleaseNotesNeeded(issue),
-                  commit: `[exivity/${sourceRepo}@${commit.sha.substring(0, 7)}](${commit.html_url})`,
+                  commit: `[exivity/${repo}@${commit.sha.substring(0, 7)}](${commit.html_url})`,
                   issue: `[${issue.key}](https://exivity.atlassian.net/browse/${issue.key})`,
                   pullRequest: associatedPullRequest
-                    ? `[exivity/${sourceRepo}#${associatedPullRequest.number}](${associatedPullRequest.url})`
+                    ? `[exivity/${repo}#${associatedPullRequest.number}](${associatedPullRequest.url})`
                     : 'No pull request',
                   milestone: epic
                     ? `[${getEpic(issue)}](https://exivity.atlassian.net/browse/${getEpic(issue)})`


### PR DESCRIPTION
## Summary
- bridge the first post-cutover release across legacy component history and the product subtree import
- keep release-note commit and PR links scoped to the repo that actually owns each commit
- add focused tests for subtree split detection and bridge-range creation

## Why
The product-backed release scan filters commits by managed path (for example `edify/`). Pre-subtree standalone commits like `exivity/edify@ab1ba36` do not touch that path, so the first release after cutover can miss valid unreleased fixes such as `EXVT-6069`. This change bridges `releasedSha .. git-subtree-split` in the legacy component repo, then continues with the existing product-path scan.

## Verification
- `yarn test:release-source-mapping`
- `yarn build:release`