### PR TITLE
chore(release): resolve product artifacts by source path

### DIFF
--- a/release/dist/index.js
+++ b/release/dist/index.js
@@ -30190,19 +30190,26 @@ var require_releaseRepositories = __commonJS({
     function groupTagTargets2(releaseRepositories) {
       const targets = /* @__PURE__ */ new Map();
       for (const repository of releaseRepositories) {
-        const existing = targets.get(repository.sourceRepo);
+        const tagStrategy = repository.tagStrategy || "component-repo";
+        const key = tagStrategy === "canonical" ? `canonical:${repository.sourceRepo}` : `${tagStrategy}:${repository.sourceRepo}`;
+        const existing = targets.get(key);
         if (!existing) {
-          targets.set(repository.sourceRepo, {
+          targets.set(key, {
             repo: repository.sourceRepo,
-            sha: repository.releasedSha,
-            components: [repository.component]
+            sha: tagStrategy === "canonical" ? void 0 : repository.releasedSha,
+            candidateShas: tagStrategy === "canonical" ? [repository.releasedSha] : void 0,
+            components: [repository.component],
+            tagStrategy
           });
           continue;
         }
-        if (existing.sha !== repository.releasedSha) {
+        if (tagStrategy !== "canonical" && existing.sha !== repository.releasedSha) {
           throw new Error(
             `Conflicting release SHAs for ${repository.sourceRepo}: ${existing.sha} and ${repository.releasedSha}`
           );
+        }
+        if (tagStrategy === "canonical" && !existing.candidateShas.includes(repository.releasedSha)) {
+          existing.candidateShas.push(repository.releasedSha);
         }
         existing.components.push(repository.component);
       }
@@ -64698,9 +64705,15 @@ async function tagRepositories(lockfile) {
   const releaseRepositories = await getReleaseRepositories();
   const tagTargets = groupTagTargets(releaseRepositories);
   for (const target of tagTargets) {
+    const sha = await resolveTagTargetSha({
+      octokit,
+      repo: target.repo,
+      sha: target.sha,
+      candidateShas: target.candidateShas
+    });
     if (isDryRun()) {
       (0, import_console4.info)(
-        `Dry run, not tagging ${target.repo} for ${target.components.join(", ")}`
+        `Dry run, not tagging ${target.repo} at ${sha} for ${target.components.join(", ")}`
       );
     } else {
       try {
@@ -64709,13 +64722,52 @@ async function tagRepositories(lockfile) {
           owner: "exivity",
           repo: target.repo,
           tag: lockfile.version,
-          sha: target.sha
+          sha
         });
       } catch (e) {
         warning(`Could not create lightweight tag on ${target.repo}: ${e}`);
       }
     }
   }
+}
+async function resolveTagTargetSha({
+  octokit,
+  repo,
+  sha,
+  candidateShas
+}) {
+  if (sha) {
+    return sha;
+  }
+  const uniqueCandidateShas = Array.from(new Set(candidateShas ?? []));
+  if (uniqueCandidateShas.length === 0) {
+    throw new Error(`Could not resolve tag target for exivity/${repo}`);
+  }
+  if (uniqueCandidateShas.length === 1) {
+    return uniqueCandidateShas[0];
+  }
+  const commits = await Promise.all(
+    uniqueCandidateShas.map(async (candidateSha) => ({
+      sha: candidateSha,
+      commit: await getCommit({
+        octokit,
+        owner: "exivity",
+        repo,
+        ref: candidateSha
+      })
+    }))
+  );
+  commits.sort((a, b) => {
+    return getCommitTime(b.commit) - getCommitTime(a.commit);
+  });
+  return commits[0].sha;
+}
+function getCommitTime(commit) {
+  const timestamp = commit.commit.author?.date ?? commit.commit.committer?.date;
+  if (!timestamp) {
+    throw new Error(`Could not determine timestamp for ${commit.sha}`);
+  }
+  return Date.parse(timestamp);
 }
 async function tagAllRepositories() {
   const lockfile = await getLockFile();
@@ -64913,12 +64965,21 @@ async function writeLockFile(version2) {
         repositories.map(({ component }) => component),
         await Promise.all(
           repositories.map(
-            ({ sourceRepo, releaseBranch: releaseBranch2 }) => getLastCommitSha({
-              octokit,
-              owner: "exivity",
-              repo: sourceRepo,
-              sha: releaseBranch2
-            })
+            async ({ component, sourceRepo, sourcePath, releaseBranch: releaseBranch2 }) => {
+              const sha = await getLastCommitSha({
+                octokit,
+                owner: "exivity",
+                repo: sourceRepo,
+                sha: releaseBranch2,
+                path: sourcePath
+              });
+              if (!sha) {
+                throw new Error(
+                  `Could not resolve release artifact SHA for ${component} from exivity/${sourceRepo}#${releaseBranch2}${sourcePath ? ` (${sourcePath})` : ""}`
+                );
+              }
+              return sha;
+            }
           )
         )
       )

--- a/release/src/common/gitActions.ts
+++ b/release/src/common/gitActions.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../lib/git'
 import {
   createLightweightTag,
+  getCommit,
   getPrFromRef,
   getRepository,
 } from '../../../lib/github'
@@ -61,14 +62,23 @@ async function tagRepositories(lockfile: Lockfile) {
   const releaseRepositories = await getReleaseRepositories()
   const tagTargets = groupTagTargets(releaseRepositories) as Array<{
     repo: string
-    sha: string
+    sha?: string
+    candidateShas?: string[]
     components: string[]
+    tagStrategy: string
   }>
 
   for (const target of tagTargets) {
+    const sha = await resolveTagTargetSha({
+      octokit,
+      repo: target.repo,
+      sha: target.sha,
+      candidateShas: target.candidateShas,
+    })
+
     if (isDryRun()) {
       info(
-        `Dry run, not tagging ${target.repo} for ${target.components.join(', ')}`,
+        `Dry run, not tagging ${target.repo} at ${sha} for ${target.components.join(', ')}`,
       )
     } else {
       try {
@@ -77,13 +87,67 @@ async function tagRepositories(lockfile: Lockfile) {
           owner: 'exivity',
           repo: target.repo,
           tag: lockfile.version,
-          sha: target.sha,
+          sha,
         })
       } catch (e) {
         warning(`Could not create lightweight tag on ${target.repo}: ${e}`)
       }
     }
   }
+}
+
+async function resolveTagTargetSha({
+  octokit,
+  repo,
+  sha,
+  candidateShas,
+}: {
+  octokit: ReturnType<typeof getOctokit>
+  repo: string
+  sha?: string
+  candidateShas?: string[]
+}) {
+  if (sha) {
+    return sha
+  }
+
+  const uniqueCandidateShas = Array.from(new Set(candidateShas ?? []))
+
+  if (uniqueCandidateShas.length === 0) {
+    throw new Error(`Could not resolve tag target for exivity/${repo}`)
+  }
+
+  if (uniqueCandidateShas.length === 1) {
+    return uniqueCandidateShas[0]
+  }
+
+  const commits = await Promise.all(
+    uniqueCandidateShas.map(async (candidateSha) => ({
+      sha: candidateSha,
+      commit: await getCommit({
+        octokit,
+        owner: 'exivity',
+        repo,
+        ref: candidateSha,
+      }),
+    })),
+  )
+
+  commits.sort((a, b) => {
+    return getCommitTime(b.commit) - getCommitTime(a.commit)
+  })
+
+  return commits[0].sha
+}
+
+function getCommitTime(commit: Awaited<ReturnType<typeof getCommit>>) {
+  const timestamp = commit.commit.author?.date ?? commit.commit.committer?.date
+
+  if (!timestamp) {
+    throw new Error(`Could not determine timestamp for ${commit.sha}`)
+  }
+
+  return Date.parse(timestamp)
 }
 
 export async function tagAllRepositories() {

--- a/release/src/common/releaseRepositories.js
+++ b/release/src/common/releaseRepositories.js
@@ -20,21 +20,39 @@ function groupTagTargets(releaseRepositories) {
   const targets = new Map()
 
   for (const repository of releaseRepositories) {
-    const existing = targets.get(repository.sourceRepo)
+    const tagStrategy = repository.tagStrategy || 'component-repo'
+    const key =
+      tagStrategy === 'canonical'
+        ? `canonical:${repository.sourceRepo}`
+        : `${tagStrategy}:${repository.sourceRepo}`
+    const existing = targets.get(key)
 
     if (!existing) {
-      targets.set(repository.sourceRepo, {
+      targets.set(key, {
         repo: repository.sourceRepo,
-        sha: repository.releasedSha,
+        sha: tagStrategy === 'canonical' ? undefined : repository.releasedSha,
+        candidateShas:
+          tagStrategy === 'canonical' ? [repository.releasedSha] : undefined,
         components: [repository.component],
+        tagStrategy,
       })
       continue
     }
 
-    if (existing.sha !== repository.releasedSha) {
+    if (
+      tagStrategy !== 'canonical' &&
+      existing.sha !== repository.releasedSha
+    ) {
       throw new Error(
         `Conflicting release SHAs for ${repository.sourceRepo}: ${existing.sha} and ${repository.releasedSha}`,
       )
+    }
+
+    if (
+      tagStrategy === 'canonical' &&
+      !existing.candidateShas.includes(repository.releasedSha)
+    ) {
+      existing.candidateShas.push(repository.releasedSha)
     }
 
     existing.components.push(repository.component)

--- a/release/src/common/releaseRepositories.test.js
+++ b/release/src/common/releaseRepositories.test.js
@@ -101,12 +101,16 @@ test('groupTagTargets deduplicates shared source repositories', () => {
     {
       repo: 'product',
       sha: 'sha-product',
+      candidateShas: undefined,
       components: ['glass', 'proximity'],
+      tagStrategy: 'component-repo',
     },
     {
       repo: 'chronos',
       sha: 'sha-chronos',
+      candidateShas: undefined,
       components: ['chronos'],
+      tagStrategy: 'component-repo',
     },
   ])
 })
@@ -128,4 +132,68 @@ test('groupTagTargets rejects conflicting SHAs for one source repository', () =>
       ]),
     /Conflicting release SHAs for product/,
   )
+})
+
+test('groupTagTargets allows different canonical SHAs for one source repository', () => {
+  const targets = groupTagTargets([
+    {
+      component: 'glass',
+      releasedSha: 'sha-product-glass',
+      sourceRepo: 'product',
+      tagStrategy: 'canonical',
+    },
+    {
+      component: 'proximity',
+      releasedSha: 'sha-product-proximity',
+      sourceRepo: 'product',
+      tagStrategy: 'canonical',
+    },
+    {
+      component: 'edify',
+      releasedSha: 'sha-product-edify',
+      sourceRepo: 'product',
+      tagStrategy: 'canonical',
+    },
+  ])
+
+  assert.deepEqual(targets, [
+    {
+      repo: 'product',
+      sha: undefined,
+      candidateShas: [
+        'sha-product-glass',
+        'sha-product-proximity',
+        'sha-product-edify',
+      ],
+      components: ['glass', 'proximity', 'edify'],
+      tagStrategy: 'canonical',
+    },
+  ])
+})
+
+test('groupTagTargets deduplicates repeated canonical SHAs', () => {
+  const targets = groupTagTargets([
+    {
+      component: 'glass',
+      releasedSha: 'sha-product',
+      sourceRepo: 'product',
+      tagStrategy: 'canonical',
+    },
+    {
+      component: 'proximity',
+      releasedSha: 'sha-product',
+      sourceRepo: 'product',
+      tagStrategy: 'canonical',
+    },
+  ])
+
+  assert.deepEqual(targets, [
+    {
+      repo: 'product',
+      sha: undefined,
+      candidateShas: ['sha-product'],
+      components: ['glass', 'proximity'],
+      tagStrategy: 'canonical',
+    },
+  ])
 })

--- a/release/src/common/writeLockFile.ts
+++ b/release/src/common/writeLockFile.ts
@@ -24,13 +24,24 @@ export async function writeLockFile(version: string) {
       repositories: zipObj(
         repositories.map(({ component }) => component),
         await Promise.all(
-          repositories.map(({ sourceRepo, releaseBranch }) =>
-            getLastCommitSha({
-              octokit,
-              owner: 'exivity',
-              repo: sourceRepo,
-              sha: releaseBranch,
-            }),
+          repositories.map(
+            async ({ component, sourceRepo, sourcePath, releaseBranch }) => {
+              const sha = await getLastCommitSha({
+                octokit,
+                owner: 'exivity',
+                repo: sourceRepo,
+                sha: releaseBranch,
+                path: sourcePath,
+              })
+
+              if (!sha) {
+                throw new Error(
+                  `Could not resolve release artifact SHA for ${component} from exivity/${sourceRepo}#${releaseBranch}${sourcePath ? ` (${sourcePath})` : ''}`,
+                )
+              }
+
+              return sha
+            },
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- resolve product-backed release lockfile entries using sourcePath-aware artifact SHAs
- allow canonical product tagging when product-backed components have different artifact SHAs
- add release source mapping tests and rebuild release action dist

## Verification
- node --test release/src/common/releaseRepositories.test.js
- ./node_modules/.bin/esbuild --bundle --platform=node --target=node24 release/src/index.ts --outfile=release/dist/index.js

Note: yarn test:release-source-mapping did not start locally because Yarn reported the workspace package was not present in the lockfile. The same test was run directly with node.